### PR TITLE
Setup/teardown handling

### DIFF
--- a/specs/spec.spec.php
+++ b/specs/spec.spec.php
@@ -50,7 +50,7 @@ describe("Spec", function() {
     it('should run tear down functions even if spec fails', function () {
         $spec = new Spec('failing spec with tear downs', function() {
             throw new Exception('fail');
-        }) ;
+        });
         $spec->addTearDownFunction(function() {
             $this->log = 'tearing down';
         });
@@ -59,7 +59,7 @@ describe("Spec", function() {
     });
 
     it('should run tear down functions even if setup fails', function () {
-        $spec = new Spec('spec', function() {}) ;
+        $spec = new Spec('spec', function() {});
         $spec->addSetUpFunction(function() {
             throw new Exception('set up failure');
         });
@@ -71,7 +71,7 @@ describe("Spec", function() {
     });
 
     it('should continue if tear down fails', function () {
-        $spec = new Spec('spec', function() {}) ;
+        $spec = new Spec('spec', function() {});
         $spec->addTearDownFunction(function() {
             throw new Exception('tear down failure');
         });
@@ -79,5 +79,17 @@ describe("Spec", function() {
         $result = new SpecResult();
         $spec->run($result);;
         assert("1 run, 0 failed" == $result->getSummary(), "result summary should have shown 1 run");
+    });
+
+    it('should skip test if set up fails', function () {
+        $spec = new Spec('spec is skipped', function() {
+            $this->log = 'testing';
+        });
+        $spec->addSetUpFunction(function() {
+            throw new Exception('set up failure');
+        });
+
+        $spec->run(new SpecResult());;
+        assert(!isset($spec->log), 'test should have been skipped');
     });
 });

--- a/src/Core/Spec.php
+++ b/src/Core/Spec.php
@@ -27,6 +27,7 @@ class Spec extends AbstractSpec
             } catch (Exception $e) {
                 $result->failSpec($this);
                 $this->runTearDown();
+                return;
             }
         }
 


### PR DESCRIPTION
Closes #4.  Closes #6.
- run tear down when spec fails
- run tear down when set up fails (test is failed)
- skip test when setup fails (test is failed)
- continue tests is tear down fails
