### PR TITLE
add time stats to base reporter and report in spec reporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "evenement/evenement": "2.0.*",
-        "symfony/console": "~2.0"
+        "symfony/console": "~2.0",
+        "phpunit/php-timer": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -43,6 +43,11 @@ abstract class AbstractBaseReporter implements ReporterInterface
     protected $pending = 0;
 
     /**
+     * @var int
+     */
+    protected $time;
+
+    /**
      * @var array
      */
     protected $colors = array(
@@ -70,6 +75,14 @@ abstract class AbstractBaseReporter implements ReporterInterface
         $this->configuration = $configuration;
         $this->runner = $runner;
         $this->output = $output;
+
+        $this->runner->on('start', function() {
+            \PHP_Timer::start();
+        });
+
+        $this->runner->on('end', function() {
+            $this->time = \PHP_Timer::stop();
+        });
 
         $this->runner->on('fail', function(Spec $spec, \Exception $e) {
             $this->errors[] = [$spec, $e];

--- a/src/Reporter/SpecReporter.php
+++ b/src/Reporter/SpecReporter.php
@@ -84,7 +84,8 @@ class SpecReporter extends AbstractBaseReporter
      */
     public function footer()
     {
-        $this->output->writeln($this->color('success', sprintf("\n  %d passing", $this->passing)));
+        $this->output->write($this->color('success', sprintf("\n  %d passing", $this->passing)));
+        $this->output->writeln(sprintf($this->color('muted', " (%s)"), \PHP_Timer::timeSinceStartOfRequest()));
         if ($this->errors) {
             $this->output->writeln($this->color('error', sprintf("  %d failing", count($this->errors))));
         }


### PR DESCRIPTION
Fixes #35 Integrate PHP_Timer for time stats. This adds a `$time` property to the base reporter and uses PHP_Timer to format it in spec reporter.
