### PR TITLE
rename spec events to test events and include peridot lifecycle events

### DIFF
--- a/peridot.php
+++ b/peridot.php
@@ -1,8 +1,6 @@
 <?php
 use Evenement\EventEmitterInterface;
-use Peridot\Configuration;
-use Peridot\Console\InputDefinition;
-use Peridot\Reporter\ReporterFactory;
+use Peridot\Console\Environment;
 use Peridot\Reporter\ReporterInterface;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -12,23 +10,23 @@ use Symfony\Component\Console\Input\InputOption;
 return function(EventEmitterInterface $emitter) {
     $counts = ['pass' => 0, 'fail' => 0, 'pending' => 0];
 
-    $emitter->on('spec.failed', function() use (&$counts) {
+    $emitter->on('test.failed', function() use (&$counts) {
         $counts['fail']++;
     });
 
-    $emitter->on('spec.passed', function() use (&$counts) {
+    $emitter->on('test.passed', function() use (&$counts) {
         $counts['pass']++;
     });
 
-    $emitter->on('spec.pending', function() use (&$counts) {
+    $emitter->on('test.pending', function() use (&$counts) {
         $counts['pending']++;
     });
 
-    $emitter->on('peridot.start', function(InputDefinition $definition) {
-        $definition->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
+    $emitter->on('peridot.start', function(Environment $env) {
+        $env->getDefinition()->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
     });
 
-    $emitter->on('peridot.preExecute', function($runner, $config, $reporters, $input) use (&$counts, $emitter) {
+    $emitter->on('peridot.reporters', function($input, $reporters) use (&$counts) {
         $banner = $input->getOption('banner');
         $reporters->register('basic', 'a simple summary', function(ReporterInterface $reporter) use (&$counts, $banner) {
             $output = $reporter->getOutput();

--- a/specs/runner.spec.php
+++ b/specs/runner.spec.php
@@ -78,7 +78,7 @@ describe("Runner", function() {
         it("should emit a fail event when a spec fails", function() {
             $emitted = null;
             $exception = null;
-            $this->eventEmitter->on('spec.failed', function($test, $e) use (&$emitted, &$exception) {
+            $this->eventEmitter->on('test.failed', function($test, $e) use (&$emitted, &$exception) {
                 $emitted = $test;
                 $exception = $e;
             });
@@ -88,7 +88,7 @@ describe("Runner", function() {
 
         it("should emit a pass event when a spec passes", function() {
             $emitted = null;
-            $this->eventEmitter->on('spec.passed', function($test) use (&$emitted) {
+            $this->eventEmitter->on('test.passed', function($test) use (&$emitted) {
                 $emitted = $test;
             });
             $this->runner->run(new TestResult($this->eventEmitter));
@@ -97,7 +97,7 @@ describe("Runner", function() {
 
         it("should emit a pending event when a spec is pending", function() {
             $emitted = null;
-            $this->eventEmitter->on('spec.pending', function($test) use (&$emitted) {
+            $this->eventEmitter->on('test.pending', function($test) use (&$emitted) {
                 $emitted = $test;
             });
             $this->passingTest->setPending(true);

--- a/specs/test-result.spec.php
+++ b/specs/test-result.spec.php
@@ -44,7 +44,7 @@ describe("TestResult", function() {
         it('should emit a spec:failed event', function() {
             $emitted = null;
             $exception = null;
-            $this->eventEmitter->on('spec.failed', function ($test, $e) use (&$emitted, &$exception){
+            $this->eventEmitter->on('test.failed', function ($test, $e) use (&$emitted, &$exception){
                 $emitted = $test;
                 $exception = $e;
             });
@@ -64,7 +64,7 @@ describe("TestResult", function() {
 
         it('should emit a spec:passed event', function() {
             $emitted = null;
-            $this->emitter->on('spec.passed', function ($test) use (&$emitted){
+            $this->emitter->on('test.passed', function ($test) use (&$emitted){
                 $emitted = $test;
             });
 
@@ -82,7 +82,7 @@ describe("TestResult", function() {
 
         it('should emit a spec:pending event', function() {
             $emitted = null;
-            $this->emitter->on('spec.pending', function ($test) use (&$emitted){
+            $this->emitter->on('test.pending', function ($test) use (&$emitted){
                 $emitted = $test;
             });
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -33,7 +33,7 @@ class Application extends ConsoleApplication
             fwrite(STDERR, "Configuration file specified but does not exist" . PHP_EOL);
             exit(1);
         }
-        $this->environment->getEventEmitter()->emit('peridot.start', [$this->environment->getDefinition()]);
+        $this->environment->getEventEmitter()->emit('peridot.start', [$this->environment]);
         parent::__construct(Version::NAME, Version::NUMBER);
     }
 
@@ -53,7 +53,11 @@ class Application extends ConsoleApplication
             $in = $this->getInput();
         }
 
-        return parent::run($in, $output);
+        $exitCode = parent::run($in, $output);
+
+        $this->environment->getEventEmitter()->emit('peridot.end', [$exitCode, $in, $output]);
+
+        return $exitCode;
     }
 
     /**
@@ -66,7 +70,6 @@ class Application extends ConsoleApplication
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         $configuration = ConfigurationReader::readInput($input);
-
         $this->environment->getEventEmitter()->emit('peridot.configure', [$configuration]);
 
         $runner = new Runner(Context::getInstance()->getCurrentSuite(), $configuration, $this->environment->getEventEmitter());

--- a/src/Core/TestResult.php
+++ b/src/Core/TestResult.php
@@ -66,7 +66,7 @@ class TestResult
     public function failTest(TestInterface $test, \Exception $e)
     {
         $this->failureCount++;
-        $this->eventEmitter->emit('spec.failed', [$test, $e]);
+        $this->eventEmitter->emit('test.failed', [$test, $e]);
     }
 
     /**
@@ -77,7 +77,7 @@ class TestResult
     public function pendTest(TestInterface $test)
     {
         $this->pendingCount++;
-        $this->eventEmitter->emit('spec.pending', [$test]);
+        $this->eventEmitter->emit('test.pending', [$test]);
     }
 
     /**
@@ -87,7 +87,7 @@ class TestResult
      */
     public function passTest(TestInterface $test)
     {
-        $this->eventEmitter->emit('spec.passed', [$test]);
+        $this->eventEmitter->emit('test.passed', [$test]);
     }
 
     /**

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -92,15 +92,15 @@ abstract class AbstractBaseReporter implements ReporterInterface
             $this->time = \PHP_Timer::stop();
         });
 
-        $this->eventEmitter->on('spec.failed', function (Test $test, \Exception $e) {
+        $this->eventEmitter->on('test.failed', function (Test $test, \Exception $e) {
             $this->errors[] = [$test, $e];
         });
 
-        $this->eventEmitter->on('spec.passed', function () {
+        $this->eventEmitter->on('test.passed', function () {
             $this->passing++;
         });
 
-        $this->eventEmitter->on('spec.pending', function () {
+        $this->eventEmitter->on('test.pending', function () {
             $this->pending++;
         });
 

--- a/src/Reporter/SpecReporter.php
+++ b/src/Reporter/SpecReporter.php
@@ -45,7 +45,7 @@ class SpecReporter extends AbstractBaseReporter
             }
         });
 
-        $this->eventEmitter->on('spec.passed', function (Test $test) {
+        $this->eventEmitter->on('test.passed', function (Test $test) {
             $this->output->writeln(sprintf(
                 "  %s%s %s",
                 $this->indent(),
@@ -54,7 +54,7 @@ class SpecReporter extends AbstractBaseReporter
             ));
         });
 
-        $this->eventEmitter->on('spec.failed', function (Test $test, \Exception $e) {
+        $this->eventEmitter->on('test.failed', function (Test $test, \Exception $e) {
             $this->output->writeln(sprintf(
                 "  %s%s",
                 $this->indent(),
@@ -62,7 +62,7 @@ class SpecReporter extends AbstractBaseReporter
             ));
         });
 
-        $this->eventEmitter->on('spec.pending', function (Test $test) {
+        $this->eventEmitter->on('test.pending', function (Test $test) {
             $this->output->writeln(sprintf(
                 $this->color('pending', "  %s- %s"),
                 $this->indent(),

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -49,7 +49,7 @@ class Runner
            $this->eventEmitter->emit('error', [$errno, $errstr, $errfile, $errline]);
         });
 
-        $this->eventEmitter->on('spec.failed', function ($test, $e) {
+        $this->eventEmitter->on('test.failed', function ($test, $e) {
             if ($this->configuration->shouldStopOnFailure()) {
                 $this->eventEmitter->emit('suite.halt');
             }

--- a/src/Runner/SuiteLoader.php
+++ b/src/Runner/SuiteLoader.php
@@ -7,7 +7,7 @@ namespace Peridot\Runner;
  *
  * @package Peridot\Runner
  */
-class SuiteLoader
+class SuiteLoader implements SuiteLoaderInterface
 {
     /**
      * @var string
@@ -23,8 +23,7 @@ class SuiteLoader
     }
 
     /**
-     * Load specs. Runs 'include' on all tests
-     * returned by getTests
+     * {@inheritdoc}
      *
      * @param $path
      */
@@ -37,9 +36,7 @@ class SuiteLoader
     }
 
     /**
-     * Search a path for a provided file or scan a
-     * directory structure for files matching the loader's
-     * pattern
+     * {@inheritdoc}
      *
      * @param $path
      * @return array

--- a/src/Runner/SuiteLoaderInterface.php
+++ b/src/Runner/SuiteLoaderInterface.php
@@ -1,0 +1,28 @@
+<?php
+namespace Peridot\Runner;
+
+/**
+ * The SuiteLoaderInterface outlines a contract for including
+ * tests
+ *
+ * @package Peridot\Runner
+ */
+interface SuiteLoaderInterface
+{
+    /**
+     * Search a path for a provided file or scan a
+     * directory structure for files matching the loader's
+     * conditions
+     *
+     * @param $path
+     * @return array
+     */
+    public function getTests($path);
+
+    /**
+     * Load tests
+     *
+     * @param $path
+     */
+    public function load($path);
+}


### PR DESCRIPTION
includes all the peridot.\* lifecycle events and renames all spec.\* events to test.\* events
