### PR TITLE
readonly access to methods and properties of mixed in scopes

### DIFF
--- a/specs/scope.spec.php
+++ b/specs/scope.spec.php
@@ -45,7 +45,7 @@ describe('Scope', function() {
     });
 });
 
-class TestScope
+class TestScope extends Scope
 {
     public $name = "brian";
 

--- a/src/Core/Scope.php
+++ b/src/Core/Scope.php
@@ -23,6 +23,14 @@ class Scope
     }
 
     /**
+     * @return array
+     */
+    public function peridotGetChildScopes()
+    {
+        return $this->peridotChildScopes;
+    }
+
+    /**
      * @param $name
      * @param $arguments
      * @return mixed

--- a/src/Core/Suite.php
+++ b/src/Core/Suite.php
@@ -86,7 +86,7 @@ class Suite extends AbstractTest
                 $test->setPending($this->getPending());
             }
 
-            $this->bindCallables($test);
+            $this->bindTest($test);
             $test->setEventEmitter($this->eventEmitter);
             $test->run($result);
         }
@@ -94,12 +94,16 @@ class Suite extends AbstractTest
     }
 
     /**
-     * Bind the suite's callables to the provided test
+     * Bind the suite's callables and scopes to the provided test
      *
      * @param $test
      */
-    public function bindCallables(TestInterface $test)
+    public function bindTest(TestInterface $test)
     {
+        $childScopes = $this->getScope()->peridotGetChildScopes();
+        foreach ($childScopes as $scope) {
+            $test->getScope()->peridotAddChildScope($scope);
+        }
         foreach ($this->setUpFns as $fn) {
             $test->addSetupFunction($fn);
         }


### PR DESCRIPTION
Oh man, we can totally mix in scopes now. Fixes #48 
