### PR TITLE
Add windows support

### DIFF
--- a/specs/configuration.spec.php
+++ b/specs/configuration.spec.php
@@ -26,7 +26,7 @@ describe('Configuration', function() {
             $path = $this->configuration->getConfigurationFile($file);
             chdir($cwd);
 
-            assert($path == "$root/$file", "paths should be equal");
+            assert(realpath($path) == realpath("$root/$file"), "paths should be equal");
         });
 
         it('should return supplied value if relative file does not exist', function() {

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -84,6 +84,11 @@ abstract class AbstractBaseReporter implements ReporterInterface
         $this->output = $output;
         $this->eventEmitter = $eventEmitter;
 
+        //update symbols for windows
+        if (DIRECTORY_SEPARATOR == '\\') {
+            $this->symbols['check'] = chr(251);
+        }
+
         $this->eventEmitter->on('runner.start', function () {
             \PHP_Timer::start();
         });


### PR DESCRIPTION
This PR checks color support and suppresses colors on Windows if not available. 
In addition, this PR updates the check symbol with an ASCII character that is supported on windows.
All tests brought to parity with Windows as well. We have green across the board!

Fixes #26 
