### PR TITLE
use methods in SpecReporter

### DIFF
--- a/src/Reporter/SpecReporter.php
+++ b/src/Reporter/SpecReporter.php
@@ -19,60 +19,95 @@ class SpecReporter extends AbstractBaseReporter
     protected $column = 0;
 
     /**
+     * @var \Peridot\Core\Suite
+     */
+    protected $root;
+
+    /**
      * Initialize reporter. Setup and listen for runner events
      *
      * @return void
      */
     public function init()
     {
-        $root = Context::getInstance()->getCurrentSuite();
+        $this->root = Context::getInstance()->getCurrentSuite();
 
-        $this->eventEmitter->on('runner.start', function () {
+        $this->eventEmitter->on('runner.start', [$this, 'onRunnerStart']);
+        $this->eventEmitter->on('suite.start', [$this, 'onSuiteStart']);
+        $this->eventEmitter->on('suite.end', [$this, 'onSuiteEnd']);
+        $this->eventEmitter->on('test.passed', [$this, 'onTestPassed']);
+        $this->eventEmitter->on('test.failed', [$this, 'onTestFailed']);
+        $this->eventEmitter->on('test.pending', [$this, 'onTestPending']);
+        $this->eventEmitter->on('runner.end', [$this, 'onRunnerEnd']);
+    }
+
+    public function onRunnerStart()
+    {
+        $this->output->writeln("");
+    }
+
+    /**
+     * @param Suite $suite
+     */
+    public function onSuiteStart(Suite $suite)  {
+        if ($suite != $this->root) {
+            ++$this->column;
+            $this->output->writeln(sprintf('%s%s', $this->indent(), $suite->getDescription()));
+        }
+    }
+
+    /**
+     * @param Suite $suite
+     */
+    public function onSuiteEnd(Suite $suite)
+    {
+        --$this->column;
+        if ($this->column == 0) {
             $this->output->writeln("");
-        });
+        }
+    }
 
-        $this->eventEmitter->on('suite.start', function (Suite $suite) use ($root) {
-            if ($suite != $root) {
-                ++$this->column;
-                $this->output->writeln(sprintf('%s%s', $this->indent(), $suite->getDescription()));
-            }
-        });
+    /**
+     * @param Test $test
+     */
+    public function onTestPassed(Test $test)
+    {
+        $this->output->writeln(sprintf(
+            "  %s%s %s",
+            $this->indent(),
+            $this->color('success', $this->symbol('check')),
+            $this->color('muted', $test->getDescription())
+        ));
+    }
 
-        $this->eventEmitter->on('suite.end', function () {
-            --$this->column;
-            if ($this->column == 0) {
-                $this->output->writeln("");
-            }
-        });
+    /**
+     * @param Test $test
+     * @param \Exception $e
+     */
+    public function onTestFailed(Test $test, \Exception $e)
+    {
+        $this->output->writeln(sprintf(
+            "  %s%s",
+            $this->indent(),
+            $this->color('error', sprintf("%d) %s", count($this->errors), $test->getDescription()))
+        ));
+    }
 
-        $this->eventEmitter->on('test.passed', function (Test $test) {
-            $this->output->writeln(sprintf(
-                "  %s%s %s",
-                $this->indent(),
-                $this->color('success', $this->symbol('check')),
-                $this->color('muted', $test->getDescription())
-            ));
-        });
+    /**
+     * @param Test $test
+     */
+    public function onTestPending(Test $test)
+    {
+        $this->output->writeln(sprintf(
+            $this->color('pending', "  %s- %s"),
+            $this->indent(),
+            $test->getDescription()
+        ));
+    }
 
-        $this->eventEmitter->on('test.failed', function (Test $test, \Exception $e) {
-            $this->output->writeln(sprintf(
-                "  %s%s",
-                $this->indent(),
-                $this->color('error', sprintf("%d) %s", count($this->errors), $test->getDescription()))
-            ));
-        });
-
-        $this->eventEmitter->on('test.pending', function (Test $test) {
-            $this->output->writeln(sprintf(
-                $this->color('pending', "  %s- %s"),
-                $this->indent(),
-                $test->getDescription()
-            ));
-        });
-
-        $this->eventEmitter->on('runner.end', function () {
-            $this->footer();
-        });
+    public function onRunnerEnd()
+    {
+        $this->footer();
     }
 
     /**


### PR DESCRIPTION
A very simple refactoring. This replace anonymous functions in the SpecReporter with instance methods. This will allow reporters to more easily override behavior (via removing listeners or just overriding methods).

This is probably a "Peridot best practice", and one we should leverage as much as possible when creating new reporters.
