### PR TITLE
AbstractTest::getDefinition always returns a bound definition

### DIFF
--- a/specs/context.spec.php
+++ b/specs/context.spec.php
@@ -40,6 +40,14 @@ describe('Context', function() {
             $suite = $this->context->addSuite("desc", function() {});
             assert(is_null($suite->getPending()), "pending status should be null");
         });
+
+        it("should execute a suites bound definition", function() {
+            $suite = $this->context->addSuite("desc", function() {
+                $this->value = "hello";
+            });
+            $scope = $suite->getScope();
+            assert($scope->value == "hello", "value should be bound to suites scope");
+        });
     });
 
     describe("->addTest()", function() {

--- a/src/Core/AbstractTest.php
+++ b/src/Core/AbstractTest.php
@@ -111,7 +111,12 @@ abstract class AbstractTest implements TestInterface
      */
     public function getDefinition()
     {
-        return $this->definition;
+        $boundDefinition = Closure::bind(
+            $this->definition,
+            $this->scope,
+            $this->scope
+        );
+        return $boundDefinition;
     }
 
     /**

--- a/src/Core/Test.php
+++ b/src/Core/Test.php
@@ -39,9 +39,8 @@ class Test extends AbstractTest
             }
         }
 
-        $boundTest = $this->getBoundDefinition();
         try {
-            call_user_func($boundTest);
+            call_user_func($this->getDefinition());
             $result->passTest($this);
         } catch (\Exception $e) {
             $result->failTest($this, $e);
@@ -63,20 +62,5 @@ class Test extends AbstractTest
                 continue;
             }
         }
-    }
-
-    /**
-     * Returns the test's definition bound to
-     * the test's scope
-     *
-     * @return Closure
-     */
-    protected function getBoundDefinition()
-    {
-        return Closure::bind(
-            $this->definition,
-            $this->scope,
-            $this->scope
-        );
     }
 }


### PR DESCRIPTION
This bugfix causes all tests to always return a "bound" definition - that is all definitions for both suites and tests are bound to scope. This will allow us to do things like this now:

``` php
describe("MyThing", function() {
    //we can bind things to a suite at this level now...
    $this->thing = "I am bound to scope";

    it("should do a thing", function() {    

    });
});
```
