### PR TITLE
peridot.start has app as second argument

### DIFF
--- a/specs/application.spec.php
+++ b/specs/application.spec.php
@@ -1,6 +1,22 @@
 <?php
+use Peridot\Console\Application;
+
 describe('Application', function() {
     include __DIR__ . '/shared/application-tester.php';
+
+    context('during construction', function() {
+        it('should emit peridot.start with environment and self', function() {
+            $ref = null;
+            $environment = null;
+            $this->emitter->on('peridot.start', function($env, $r) use (&$ref, &$environment) {
+                $ref = $r;
+                $environment = $env;
+            });
+            $application = new Application($this->environment);
+            assert($ref === $application, "application reference should be emitted");
+            assert($environment === $this->environment, "environment reference should be emitted");
+        });
+    });
 
     describe('->loadDsl()', function() {
         it('should include a file if it exists', function() {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -33,7 +33,7 @@ class Application extends ConsoleApplication
             fwrite(STDERR, "Configuration file specified but does not exist" . PHP_EOL);
             exit(1);
         }
-        $this->environment->getEventEmitter()->emit('peridot.start', [$this->environment]);
+        $this->environment->getEventEmitter()->emit('peridot.start', [$this->environment, $this]);
         parent::__construct(Version::NAME, Version::NUMBER);
     }
 


### PR DESCRIPTION
peridot.start now includes a reference to the peridot application itself - thinking this will be useful for things like watchers or something else that might want to re run peridot.
