### PR TITLE
ensure application does not load a dsl twice

### DIFF
--- a/fixtures/rad.dsl2.php
+++ b/fixtures/rad.dsl2.php
@@ -1,0 +1,5 @@
+<?php
+function peridotRad2Describe()
+{
+    //this describes things, but in a rad fashion
+}

--- a/specs/application.spec.php
+++ b/specs/application.spec.php
@@ -23,6 +23,11 @@ describe('Application', function() {
             $this->application->loadDsl(__DIR__ . '/../fixtures/rad.dsl.php');
             assert(function_exists('peridotRadDescribe'), 'dsl should have been included');
         });
+
+        it('should not include the same dsl twice', function() {
+            $this->application->loadDsl(__DIR__ . '/../fixtures/rad.dsl2.php');
+            $this->application->loadDsl(__DIR__ . '/../fixtures/rad.dsl2.php');
+        });
     });
 
     describe('->getCommandName()', function() {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -112,12 +112,12 @@ class Application extends ConsoleApplication
     /**
      * Load the configured DSL.
      *
-     * @param $configuration
+     * @param $dsl
      */
     public function loadDsl($dslPath)
     {
         if (file_exists($dslPath)) {
-            include $dslPath;
+            include_once $dslPath;
         }
     }
 


### PR DESCRIPTION
a dsl should never be loaded twice. this will prevent global functions from being defined multiple times by the same application running twice.
