### PR TITLE
overwrite Application::run to use command if name exists already

### DIFF
--- a/specs/application.spec.php
+++ b/specs/application.spec.php
@@ -42,4 +42,21 @@ describe('Application', function() {
             assert(!is_null($input), "getInput should return an input");
         });
     });
+
+    describe('->add()', function() {
+        it('should not overwrite a command of the same name', function() {
+            $tester = new TestCommand();
+            $this->application->add($tester);
+            $again = $this->application->add($tester);
+            assert($tester === $again, "expected first command instance");
+        });
+    });
 });
+
+class TestCommand extends \Symfony\Component\Console\Command\Command
+{
+    public function __construct()
+    {
+        parent::__construct('tester');
+    }
+}

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,11 +1,11 @@
 <?php
 namespace Peridot\Console;
 
-use Peridot\Configuration;
 use Peridot\Reporter\ReporterFactory;
 use Peridot\Runner\Context;
 use Peridot\Runner\Runner;
 use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Command\Command as ConsoleCommand;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -79,6 +79,25 @@ class Application extends ConsoleApplication
 
         return $exitCode;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * This implementation of run will not over write commands
+     * in the internal collection if one of the same name already
+     * exists
+     *
+     * @param \Symfony\Component\Console\Command\Command $command
+     * @return \Symfony\Component\Console\Command\Command
+     */
+    public function add(ConsoleCommand $command)
+    {
+        if ($this->has($command->getName())) {
+            return $this->get($command->getName());
+        }
+        return parent::add($command);
+    }
+
 
     /**
      * Fetch the ArgvInput used by Peridot. If any exceptions are thrown due to


### PR DESCRIPTION
This PR will prevent the application from over writing commands that have already been defined. This is preferable as to maintain references in the command itself.
