### PR TITLE
include config file in environment

### DIFF
--- a/src/Console/Environment.php
+++ b/src/Console/Environment.php
@@ -79,13 +79,12 @@ class Environment
         }
 
         $files = array_filter(['c', 'configuration'], [$this, 'optionIsFile']);
-        $file = array_pop($files);
 
-        if (is_null($file)) {
+        if (empty($files)) {
             return false;
         }
 
-        return $this->includeConfiguration($file);
+        return $this->includeConfiguration($this->options[array_pop($files)]);
     }
 
     /**


### PR DESCRIPTION
Manually specified configuration files were not being included. An attempt to include the key instead of the file itself was occurring.
