### PR TITLE
use ansi sequence in colors and set tty env variable

### DIFF
--- a/specs/abstract-base-reporter.spec.php
+++ b/specs/abstract-base-reporter.spec.php
@@ -2,6 +2,7 @@
 use Evenement\EventEmitter;
 use Peridot\Configuration;
 use Peridot\Reporter\AbstractBaseReporter;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
 describe('AbstractBaseReporter', function() {
@@ -35,7 +36,29 @@ describe('AbstractBaseReporter', function() {
 
             it ('should add escape sequences if ansicon is enabled', function() {
                 $colored = $this->reporter->color('success', 'good');
-                assert($colored == '<fg=green>good</fg=green>', "expected color with ansicon enabled");
+                assert($colored == "\033[32mgood\033[39m", "expected color with ansicon enabled");
+            });
+        });
+
+        context('when in a tty terminal', function() {
+
+            beforeEach(function() {
+                $this->reporter = new TtyTestReporter(new Configuration(), new ConsoleOutput(), new EventEmitter());
+            });
+
+            afterEach(function() {
+                putenv('PERIDOT_TTY=');
+            });
+
+            it('should set the PERIDOT_TTY environment variable', function() {
+                $this->reporter->color('success', 'text');
+                assert(getenv('PERIDOT_TTY') !== false, "peridot tty environment variable should have been set");
+            });
+
+            it('should write colors if the PERIDOT_TTY environment variable is present', function() {
+                putenv('PERIDOT_TTY=1');
+                $text = $this->reporter->color('success', 'text');
+                assert("\033[32mtext\033[39m" == $text, "colored text should have been written");
             });
         });
     });
@@ -51,5 +74,18 @@ class WindowsTestReporter extends AbstractBaseReporter
     protected function isOnWindows()
     {
         return true;
+    }
+}
+
+class TtyTestReporter extends AbstractBaseReporter
+{
+    public function init()
+    {
+
+    }
+
+    protected function isOnWindows()
+    {
+        return false;
     }
 }

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -53,11 +53,11 @@ abstract class AbstractBaseReporter implements ReporterInterface
      * @var array
      */
     protected $colors = array(
-        'white' => ['left' => '<fg=white>', 'right' => '</fg=white>'],
-        'success' => ['left' => '<fg=green>', 'right' => '</fg=green>'],
-        'error' => ['left' => '<fg=red>', 'right' => '</fg=red>'],
+        'white' => ['left' => "\033[37m", 'right' => "\033[39m"],
+        'success' => ['left' => "\033[32m", 'right' => "\033[39m"],
+        'error' => ['left' => "\033[31m", 'right' => "\033[39m"],
         'muted' => ['left' => "\033[90m", 'right' => "\033[0m"],
-        'pending' => ['left' => '<fg=cyan>', 'right' => '</fg=cyan>'],
+        'pending' => ['left' => "\033[36m", 'right' => "\033[39m"],
     );
 
     /**
@@ -254,7 +254,15 @@ abstract class AbstractBaseReporter implements ReporterInterface
      */
     private function hasTty()
     {
-        return function_exists('posix_isatty') && @posix_isatty($this->output->getStream());
+        if (getenv("PERIDOT_TTY")) {
+            return true;
+        }
+
+        $tty = function_exists('posix_isatty') && @posix_isatty($this->output->getStream());
+        if ($tty) {
+            putenv("PERIDOT_TTY=1");
+        }
+        return $tty;
     }
 
     /**


### PR DESCRIPTION
This PR removes use of Symfony color tags and uses raw ansi sequences. 

In addition to this, when color support is detected, an environment variable is set so sub processes know to use ansi sequences as well.
