### PR TITLE
include indents for new lines in test exceptions using AbstractBaseRepor...

### DIFF
--- a/specs/spec-reporter.spec.php
+++ b/specs/spec-reporter.spec.php
@@ -48,7 +48,7 @@ describe('SpecReporter', function() {
 
             $exception = null;
             try {
-                throw new Exception("ooops");
+                throw new Exception("ooops" . PHP_EOL . "nextline");
             } catch (Exception $e) {
                 $exception = $e;
             }
@@ -79,7 +79,8 @@ describe('SpecReporter', function() {
         });
 
         it('should display exception stacks and messages', function() {
-            assert(strstr($this->contents, $this->exception->getMessage()) !== false, "should include exception message");
+            $expectedExceptionMessage = "     ooops" . PHP_EOL . "     nextline";
+            assert(strstr($this->contents, $expectedExceptionMessage) !== false, "should include exception message");
             $trace = preg_replace('/^#/m', "      #", $this->exception->getTraceAsString());
             assert(strstr($this->contents, $trace) !== false, "should include exception stack");
         });

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -5,6 +5,7 @@ use Evenement\EventEmitterInterface;
 use Peridot\Configuration;
 use Peridot\Core\HasEventEmitterTrait;
 use Peridot\Core\Test;
+use Peridot\Core\TestInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -165,11 +166,26 @@ abstract class AbstractBaseReporter implements ReporterInterface
         $errorCount = count($this->errors);
         for ($i = 0; $i < $errorCount; $i++) {
             list($test, $error) = $this->errors[$i];
-            $this->output->writeln(sprintf("  %d)%s:", $i + 1, $test->getTitle()));
-            $this->output->writeln($this->color('error', sprintf("     %s", $error->getMessage())));
-            $trace = preg_replace('/^#/m', "      #", $error->getTraceAsString());
-            $this->output->writeln($this->color('muted', $trace));
+            $this->outputError($i + 1, $test, $error);
         }
+    }
+
+    /**
+     * Output a test failure.
+     *
+     * @param int $errorIndex
+     * @param Test $test
+     * @param \Exception $exception
+     */
+    protected function outputError($errorNumber, TestInterface $test, \Exception $exception)
+    {
+        $this->output->writeln(sprintf("  %d)%s:", $errorNumber, $test->getTitle()));
+
+        $message = sprintf("     %s", str_replace(PHP_EOL, PHP_EOL . "     ", $exception->getMessage()));
+        $this->output->writeln($this->color('error', $message));
+
+        $trace = preg_replace('/^#/m', "      #", $exception->getTraceAsString());
+        $this->output->writeln($this->color('muted', $trace));
     }
 
     /**


### PR DESCRIPTION
...ter::footer

If a test exception includes new lines, these will not be indented.

Fixes #107 
