### PR TITLE
include autoload relative to vendor/bin

### DIFF
--- a/bin/peridot
+++ b/bin/peridot
@@ -4,7 +4,8 @@
 $autoloaders = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/vendor/autoload.php'
+    __DIR__ . '/vendor/autoload.php',
+    __DIR__ . '/../autoload.php'
 ];
 
 foreach ($autoloaders as $file) {


### PR DESCRIPTION
Fixes #110 

Adds autoload relative to vendor/bin - as is the case looked for in hhvm 3.5 nightly.
