### PR TITLE
allow configuration of application Runner

### DIFF
--- a/specs/application.spec.php
+++ b/specs/application.spec.php
@@ -1,5 +1,8 @@
 <?php
 use Peridot\Console\Application;
+use Peridot\Core\Suite;
+use Peridot\Runner\Runner;
+use Peridot\Runner\RunnerInterface;
 
 describe('Application', function() {
     include __DIR__ . '/shared/application-tester.php';
@@ -40,6 +43,39 @@ describe('Application', function() {
         it('should return an input', function() {
             $input = $this->application->getInput(['foo.php', 'bar']);
             assert(!is_null($input), "getInput should return an input");
+        });
+    });
+
+    describe('->getEnvironment()', function() {
+        it('should return the Environment used by the application', function() {
+            $env = $this->application->getEnvironment();
+            assert($env === $this->environment);
+        });
+    });
+
+    describe('configuration accessors', function() {
+        it('should allow access to configuration', function() {
+            $this->application->setConfiguration($this->configuration);
+            assert($this->application->getConfiguration() === $this->configuration);
+        });
+    });
+
+    describe('runner accessors', function() {
+        beforeEach(function() {
+            $this->runner = new Runner(new Suite('desc', function() {}), $this->configuration, $this->environment->getEventEmitter());
+        });
+
+        it('should allow access to runner', function() {
+            $this->application->setRunner($this->runner);
+            assert($this->application->getRunner() === $this->runner);
+        });
+
+        context('when getting Runner', function() {
+            it('should return a default runner if none set', function() {
+                $this->application->setConfiguration($this->configuration);
+                $runner = $this->application->getRunner();
+                assert($runner instanceof RunnerInterface);
+            });
         });
     });
 });

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -12,7 +12,7 @@ use Peridot\Core\Suite;
  *
  * @package Peridot\Runner
  */
-class Runner
+class Runner implements RunnerInterface
 {
     use HasEventEmitterTrait;
 
@@ -39,15 +39,13 @@ class Runner
     }
 
     /**
-     * Run the Suite
+     * {@inheritdoc}
      *
      * @param TestResult $result
      */
     public function run(TestResult $result)
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            $this->eventEmitter->emit('error', [$errno, $errstr, $errfile, $errline]);
-        });
+        $this->handleErrors();
 
         $this->eventEmitter->on('test.failed', function () {
             if ($this->configuration->shouldStopOnFailure()) {
@@ -61,5 +59,15 @@ class Runner
         $this->eventEmitter->emit('runner.end');
 
         restore_error_handler();
+    }
+
+    /**
+     * Set an error handler to broadcast an error event.
+     */
+    protected function handleErrors()
+    {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            $this->eventEmitter->emit('error', [$errno, $errstr, $errfile, $errline]);
+        });
     }
 }

--- a/src/Runner/RunnerInterface.php
+++ b/src/Runner/RunnerInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Peridot\Runner;
+
+use Peridot\Core\TestResult;
+
+/**
+ * The RunnerInterface defines how a runner should run tests
+ * and populate results.
+ *
+ * @package Peridot\Runner
+ */
+interface RunnerInterface
+{
+    /**
+     * Run the Suite
+     *
+     * @param TestResult $result
+     */
+    public function run(TestResult $result);
+}


### PR DESCRIPTION
This PR opens up getters and setters for `Configuration` and `Runner` in the `Application` class.

In addition, it opens up a getter for the `Environment` of the peridot application.

The `peridot.configure` event has been extended to pass a second argument to listeners that is the `Application` instance itself. This allows a listener to override the Runner used.

`RunnerInterface` introduced to allow implementations to be written against it.