### PR TITLE
Feature/context clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This will output documentation to the docs/ directory.
 Peridot's test suite can be run using Peridot:
 
 ```
-$ bin/peridot specs/
+$ bin/peridot
 ```
 
 And a sample of output:

--- a/peridot.php
+++ b/peridot.php
@@ -55,7 +55,9 @@ return function(EventEmitterInterface $emitter) {
     }
 
     $emitter->on('peridot.start', function(Environment $env) use (&$coverage) {
-        $env->getDefinition()->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
+        $definition = $env->getDefinition();
+        $definition->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
+        $definition->getArgument('path')->setDefault('specs');
     });
 
     $emitter->on('peridot.reporters', function($input, $reporters) use (&$counts) {

--- a/specs/context.spec.php
+++ b/specs/context.spec.php
@@ -52,7 +52,7 @@ describe('Context', function() {
         });
     });
 
-    describe("->addTest()", function() {
+    describe('->addTest()', function() {
         it("should set pending status if value is not null", function() {
             $test = $this->context->addTest("is a spec", function() {}, true);
             assert($test->getPending(), "pending status should be true");
@@ -66,6 +66,21 @@ describe('Context', function() {
         it("should set pending to true if definition is null", function() {
             $test = $this->context->addTest("is a spec");
             assert($test->getPending(), "pending status should be true");
+        });
+
+        it('should increase size of root suite', function () {
+            $this->context->addTest('spec', function () { });
+            $suite = $this->context->getCurrentSuite();
+            assert(sizeof($suite->getTests()) > 0, 'should have added test to root suite');
+        });
+    });
+
+    describe('->clear()', function () {
+        it('should reset loaded suites', function () {
+            $this->context->addTest('spec', function () { });
+            $this->context->clear();
+            $suite = $this->context->getCurrentSuite();
+            assert(sizeof($suite->getTests()) === 0, 'should have cleared root suite');
         });
     });
 

--- a/src/Runner/Context.php
+++ b/src/Runner/Context.php
@@ -27,6 +27,16 @@ class Context
      */
     private function __construct()
     {
+        $this->clear();
+    }
+
+    /**
+     * Clear the internal suite structure.
+     *
+     * @return void
+     */
+    public function clear()
+    {
         $this->suites = [new Suite("", function () {
             //noop
         })];


### PR DESCRIPTION
This PR adds a method for clearing out suites added by `Context`. 

The rationale for this is that it should allow a single process to leverage context more practically without worrying about loading more than is needed.

```php
// some script opened in a process
$pathToSuite = fgets($stdin);
include $pathToSuite  // <-- should cause Context to add suites
$context = Context::getInstance();

$suite = $context->getCurrentSuite();
$runner = new Runner();
$runner->run($suite); // <--- execute the suites included by $pathToSuite

$context->clear(); // <-- clean up after yourself so next suite read on the process can be run in isolation
```

This is most definitely being added to the API to support the `peridot-php/peridot-concurrency` library.