### PR TITLE
remove exception type hints

### DIFF
--- a/src/Core/TestResult.php
+++ b/src/Core/TestResult.php
@@ -62,11 +62,12 @@ class TestResult
      * Fail the given test.
      *
      * @param TestInterface $test
+     * @param mixed $exception
      */
-    public function failTest(TestInterface $test, \Exception $e)
+    public function failTest(TestInterface $test, $exception)
     {
         $this->failureCount++;
-        $this->eventEmitter->emit('test.failed', [$test, $e]);
+        $this->eventEmitter->emit('test.failed', [$test, $exception]);
     }
 
     /**

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -175,9 +175,9 @@ abstract class AbstractBaseReporter implements ReporterInterface
      *
      * @param int $errorIndex
      * @param Test $test
-     * @param \Exception $exception
+     * @param $exception - an exception like interface with ->getMessage(), ->getTraceAsString()
      */
-    protected function outputError($errorNumber, TestInterface $test, \Exception $exception)
+    protected function outputError($errorNumber, TestInterface $test, $exception)
     {
         $this->output->writeln(sprintf("  %d)%s:", $errorNumber, $test->getTitle()));
 
@@ -240,7 +240,7 @@ abstract class AbstractBaseReporter implements ReporterInterface
             $this->time = \PHP_Timer::stop();
         });
 
-        $this->eventEmitter->on('test.failed', function (Test $test, \Exception $e) {
+        $this->eventEmitter->on('test.failed', function (Test $test, $e) {
             $this->errors[] = [$test, $e];
         });
 


### PR DESCRIPTION
Exception type hinting is pretty limiting in a couple of places. All we really need is an "Exception like" interface, but PHP does not provide such a thing, but it does allow us to remove type hints!

It has only been removed where it makes sense - such as outputting an error and the error object being emitted as part of test failure.

This basically creates an implicit contract that if your object has the same methods as an Exception, you should be golden - not to mention that it will still be mostly exceptions used.

My use case for this is hydrating exceptions out of serialized contexts in the peridot-concurrency plugin.