### PR TITLE
add runner accessors to Command

### DIFF
--- a/specs/command.spec.php
+++ b/specs/command.spec.php
@@ -18,7 +18,16 @@ describe('Command', function() {
         });
 
         it('should allow getting a default loader', function() {
-            assert(!is_null($this->command->getLoader()), "command should have default loader");
+            assert(!is_null($this->command->getLoader()), 'command should have default loader');
+        });
+    });
+
+    describe('runner accessors', function() {
+        it('should allow setting and getting of the runner', function () {
+            $suite = new Suite('description', function () {});
+            $runner = new Runner($suite, $this->configuration, $this->emitter);
+            $this->command->setRunner($runner);
+            assert($runner === $this->command->getRunner(), 'runner should be accessible from command');
         });
     });
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -6,7 +6,7 @@ use Peridot\Configuration;
 use Peridot\Core\HasEventEmitterTrait;
 use Peridot\Core\TestResult;
 use Peridot\Reporter\ReporterFactory;
-use Peridot\Runner\Runner;
+use Peridot\Runner\RunnerInterface;
 use Peridot\Runner\SuiteLoader;
 use Peridot\Runner\SuiteLoaderInterface;
 use Symfony\Component\Console\Command\Command as ConsoleCommand;
@@ -24,7 +24,7 @@ class Command extends ConsoleCommand
     use HasEventEmitterTrait;
 
     /**
-     * @var \Peridot\Runner\Runner
+     * @var \Peridot\Runner\RunnerInterface
      */
     protected $runner;
 
@@ -44,13 +44,13 @@ class Command extends ConsoleCommand
     protected $loader;
 
     /**
-     * @param Runner $runner
+     * @param RunnerInterface $runner
      * @param Configuration $configuration
      * @param ReporterFactory $factory
      * @param EventEmitterInterface $eventEmitter
      */
     public function __construct(
-        Runner $runner,
+        RunnerInterface $runner,
         Configuration $configuration,
         ReporterFactory $factory,
         EventEmitterInterface $eventEmitter
@@ -86,6 +86,29 @@ class Command extends ConsoleCommand
             return new SuiteLoader($this->configuration->getGrep());
         }
         return $this->loader;
+    }
+
+    /**
+     * Set the suite runner used by the Peridot command.
+     *
+     * @param RunnerInterface $runner
+     * @return $this
+     */
+    public function setRunner(RunnerInterface $runner)
+    {
+        $this->runner = $runner;
+        return $this;
+    }
+
+    /**
+     * Return the runner used by the Peridot command. Defaults to
+     * an instance of Peridot\Runner\Runner.
+     *
+     * @return RunnerInterface
+     */
+    public function getRunner()
+    {
+        return $this->runner;
     }
 
     /**


### PR DESCRIPTION
Fixes #121 

Please note the intended 2.0 goal mentioned by #120 - once runner initialization is added to the command, we can have a default runner result of `Peridot\Runner\Runner`, similar to how the default loader mechanism works in the command.