### PR TITLE
Set test path on test objects

### DIFF
--- a/specs/context.spec.php
+++ b/specs/context.spec.php
@@ -52,22 +52,6 @@ describe('Context', function() {
         });
     });
 
-    describe('->setFile()', function () {
-        beforeEach(function () {
-            $this->context->setFile(__FILE__);
-        });
-
-        it('should set the file on suites added via context', function () {
-            $suite = $this->context->addSuite('desc', function() {});
-            assert($suite->getFile() === __FILE__);
-        });
-
-        it('should set the file on tests added via context', function () {
-            $test = $this->context->addTest('desc', function() {}, true);
-            assert($test->getFile() === __FILE__);
-        });
-    });
-
     describe('->addTest()', function() {
         it("should set pending status if value is not null", function() {
             $test = $this->context->addTest("is a spec", function() {}, true);
@@ -88,6 +72,22 @@ describe('Context', function() {
             $this->context->addTest('spec', function () { });
             $suite = $this->context->getCurrentSuite();
             assert(sizeof($suite->getTests()) > 0, 'should have added test to root suite');
+        });
+    });
+
+    describe('->setFile()', function () {
+        beforeEach(function () {
+            $this->context->setFile(__FILE__);
+        });
+
+        it('should set the file on suites added via context', function () {
+            $suite = $this->context->addSuite('desc', function() {});
+            assert($suite->getFile() === $this->context->getFile());
+        });
+
+        it('should set the file on tests added via context', function () {
+            $test = $this->context->addTest('desc', function() {}, true);
+            assert($test->getFile() === $this->context->getFile());
         });
     });
 

--- a/specs/context.spec.php
+++ b/specs/context.spec.php
@@ -52,6 +52,22 @@ describe('Context', function() {
         });
     });
 
+    describe('->setFile()', function () {
+        beforeEach(function () {
+            $this->context->setFile(__FILE__);
+        });
+
+        it('should set the file on suites added via context', function () {
+            $suite = $this->context->addSuite('desc', function() {});
+            assert($suite->getFile() === __FILE__);
+        });
+
+        it('should set the file on tests added via context', function () {
+            $test = $this->context->addTest('desc', function() {}, true);
+            assert($test->getFile() === __FILE__);
+        });
+    });
+
     describe('->addTest()', function() {
         it("should set pending status if value is not null", function() {
             $test = $this->context->addTest("is a spec", function() {}, true);

--- a/specs/suite.spec.php
+++ b/specs/suite.spec.php
@@ -164,6 +164,14 @@ describe("Suite", function() {
             assert(empty($tests), "tests should be empty");
         });
     });
+
+    describe('file accessors', function () {
+        it('should allow access to the file property', function () {
+            $this->suite->setFile(__FILE__);
+            $file = $this->suite->getFile();
+            assert($file === __FILE__);
+        });
+    });
 });
 
 class SuiteScope extends Scope

--- a/specs/suiteloader.spec.php
+++ b/specs/suiteloader.spec.php
@@ -1,11 +1,18 @@
 <?php
+use Peridot\Runner\Context;
 use Peridot\Runner\SuiteLoader;
 
 describe("SuiteLoader", function() {
 
     beforeEach(function() {
-       $this->loader = new SuiteLoader('*.spec.php');
-       $this->fixtures = __DIR__ . '/../fixtures';
+        $this->loader = new SuiteLoader('*.spec.php');
+        $this->fixtures = __DIR__ . '/../fixtures';
+        $this->context = Context::getInstance();
+        $this->file = $this->context->getFile();
+    });
+
+    afterEach(function () {
+        $this->context->setFile($this->file);
     });
 
     describe('->getTests()', function() {
@@ -36,6 +43,14 @@ describe("SuiteLoader", function() {
             $loader->load($this->fixtures);
             $exists = function_exists('notaspec');
             assert($exists, 'loader should have included file matching glob pattern');
+        });
+
+        it('should set the context file path', function() {
+            $loader = new SuiteLoader('test2.spec.php');
+            $loader->load($this->fixtures);
+            $expected = $this->fixtures . '/test2.spec.php';
+            $actual = $this->context->getFile();
+            assert($actual === $expected, "expected $expected, got $actual");
         });
     });
 

--- a/specs/test.spec.php
+++ b/specs/test.spec.php
@@ -247,4 +247,12 @@ describe("Test", function() {
             assert($scope === $test->getScope(), "scope should be parent scope");
         });
     });
+    
+    describe('file accessors', function () {
+        it('should allow access to the file property', function () {
+            $this->suite->setFile(__FILE__);
+            $file = $this->suite->getFile();
+            assert($file === __FILE__);
+        });
+    });
 });

--- a/specs/test.spec.php
+++ b/specs/test.spec.php
@@ -250,8 +250,9 @@ describe("Test", function() {
 
     describe('file accessors', function () {
         it('should allow access to the file property', function () {
-            $this->suite->setFile(__FILE__);
-            $file = $this->suite->getFile();
+            $test = new Test('test');
+            $test->setFile(__FILE__);
+            $file = $test->getFile();
             assert($file === __FILE__);
         });
     });

--- a/specs/test.spec.php
+++ b/specs/test.spec.php
@@ -247,7 +247,7 @@ describe("Test", function() {
             assert($scope === $test->getScope(), "scope should be parent scope");
         });
     });
-    
+
     describe('file accessors', function () {
         it('should allow access to the file property', function () {
             $this->suite->setFile(__FILE__);

--- a/src/Core/AbstractTest.php
+++ b/src/Core/AbstractTest.php
@@ -53,6 +53,11 @@ abstract class AbstractTest implements TestInterface
     protected $scope;
 
     /**
+     * @var string
+     */
+    protected $file;
+
+    /**
      * @param string   $description
      * @param callable $definition
      */
@@ -235,6 +240,27 @@ abstract class AbstractTest implements TestInterface
     public function setScope(Scope $scope)
     {
         $this->scope = $scope;
+        return $this;
+    }
+
+    /**
+     * Get the file this test belongs to.
+     *
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Set the file this test belongs to.
+     *
+     * @param string $file
+     */
+    public function setFile($file)
+    {
+        $this->file = $file;
         return $this;
     }
 }

--- a/src/Runner/Context.php
+++ b/src/Runner/Context.php
@@ -61,6 +61,14 @@ class Context
     }
 
     /**
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
      * @return \Peridot\Core\Suite
      */
     public function getCurrentSuite()

--- a/src/Runner/Context.php
+++ b/src/Runner/Context.php
@@ -18,6 +18,11 @@ class Context
     protected $suites;
 
     /**
+     * @var string
+     */
+    protected $file;
+
+    /**
      * @var Context
      */
     private static $instance = null;
@@ -43,6 +48,19 @@ class Context
     }
 
     /**
+     * Set the file for the context. This file
+     * generally represents the current file being used
+     * to load suites.
+     *
+     * @param $path
+     * @return void
+     */
+    public function setFile($path)
+    {
+        $this->file = $path;
+    }
+
+    /**
      * @return \Peridot\Core\Suite
      */
     public function getCurrentSuite()
@@ -63,6 +81,7 @@ class Context
         if (!is_null($pending)) {
             $suite->setPending($pending);
         }
+        $suite->setFile($this->file);
         $this->getCurrentSuite()->addTest($suite);
         array_unshift($this->suites, $suite);
         call_user_func($suite->getDefinition());
@@ -83,6 +102,7 @@ class Context
         if (!is_null($pending)) {
             $test->setPending($pending);
         }
+        $test->setFile($this->file);
         $this->getCurrentSuite()->addTest($test);
 
         return $test;

--- a/src/Runner/SuiteLoader.php
+++ b/src/Runner/SuiteLoader.php
@@ -15,11 +15,17 @@ class SuiteLoader implements SuiteLoaderInterface
     protected $pattern;
 
     /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
      * @param string $pattern
      */
     public function __construct($pattern)
     {
         $this->pattern = $pattern;
+        $this->context = Context::getInstance();
     }
 
     /**
@@ -31,6 +37,7 @@ class SuiteLoader implements SuiteLoaderInterface
     {
         $tests = $this->getTests($path);
         foreach ($tests as $test) {
+            $this->context->setFile($test);
             include $test;
         }
     }


### PR DESCRIPTION
It would generally be useful to have the file path available on test objects - for information/reporting purposes.

This PR updates the context with a file path based on what file is being loaded. All suites or tests included will receive file information from the context when created by it.

Fixes #124 