### PR TITLE
runner.end now supplies run time as float

### DIFF
--- a/specs/runner.spec.php
+++ b/specs/runner.spec.php
@@ -65,14 +65,14 @@ describe("Runner", function() {
             assert($emitted, 'start event should have been emitted');
         });
 
-        it("should emit an end event when the runner ends", function() {
-            $emitted = false;
-            $this->eventEmitter->on('runner.end', function() use (&$emitted) {
-                $emitted = true;
+        it("should emit an end event with run time when the runner ends", function() {
+            $time = null;
+            $this->eventEmitter->on('runner.end', function($timeToRun) use (&$time) {
+                $time = $timeToRun;
             });
             $result = new TestResult(new EventEmitter());
             $this->runner->run($result);
-            assert($emitted && $result->getTestCount() > 0, 'end event should have been emitted');
+            assert(is_numeric($time) && $result->getTestCount() > 0, 'end event with a time arg should have been emitted');
         });
 
         it("should emit a fail event when a spec fails", function() {

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -142,7 +142,19 @@ abstract class AbstractBaseReporter implements ReporterInterface
     }
 
     /**
-     * @return double|integer
+     * Set the run time to report.
+     *
+     * @param float $time
+     */
+    public function setTime($time)
+    {
+        $this->time = $time;
+    }
+
+    /**
+     * Get the run time to report.
+     *
+     * @return float
      */
     public function getTime()
     {
@@ -234,11 +246,7 @@ abstract class AbstractBaseReporter implements ReporterInterface
      */
     private function registerEvents()
     {
-        $this->eventEmitter->on('runner.start', ['\PHP_Timer', 'start']);
-
-        $this->eventEmitter->on('runner.end', function () {
-            $this->time = \PHP_Timer::stop();
-        });
+        $this->eventEmitter->on('runner.end', [$this, 'setTime']);
 
         $this->eventEmitter->on('test.failed', function (Test $test, $e) {
             $this->errors[] = [$test, $e];

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -55,8 +55,9 @@ class Runner implements RunnerInterface
 
         $this->eventEmitter->emit('runner.start');
         $this->suite->setEventEmitter($this->eventEmitter);
+        $start = microtime(true);
         $this->suite->run($result);
-        $this->eventEmitter->emit('runner.end');
+        $this->eventEmitter->emit('runner.end', [microtime(true) - $start]);
 
         restore_error_handler();
     }


### PR DESCRIPTION
It makes sense that the runner should supply how long it took to do its thing. This passes an end time as a float, so PHP_Timer static calls are avoided.

Fixes #129 