### PR TITLE
include accessors to test result counts

### DIFF
--- a/specs/test-result.spec.php
+++ b/specs/test-result.spec.php
@@ -134,13 +134,27 @@ describe("TestResult", function() {
         });
     });
 
-    describe("->getPendingCount()", function() {
-        it("should return the pending count tracked by the result", function() {
+    describe('pending test accessors', function () {
+        it('should allow access to the total number of pending tests', function () {
             $result = new TestResult($this->eventEmitter);
-            $pending = new Test("pending");
-            $result->pendTest($pending);
-            $count = $result->getPendingCount();
-            assert($count == 1, "pending count should be 1");
+            $result->setPendingCount(1);
+            assert($result->getPendingCount() === 1, 'should have returned pending count');
+        });
+    });
+
+    describe('failure accessors', function () {
+        it('should allow access to the total number of failures', function () {
+            $result = new TestResult($this->eventEmitter);
+            $result->setFailureCount(1);
+            assert($result->getFailureCount() === 1, 'should have returned failure count');
+        });
+    });
+
+    describe('test count accessors', function () {
+        it('should allow access to the total number of tests', function () {
+            $result = new TestResult($this->eventEmitter);
+            $result->setTestCount(1);
+            assert($result->getTestCount() === 1, 'should have returned test count');
         });
     });
 });

--- a/src/Core/TestResult.php
+++ b/src/Core/TestResult.php
@@ -113,6 +113,8 @@ class TestResult
     }
 
     /**
+     * Get the number of failures tracked by this result.
+     *
      * @return int
      */
     public function getFailureCount()
@@ -121,6 +123,20 @@ class TestResult
     }
 
     /**
+     * Set the number of failures tracked by this result.
+     *
+     * @param int $failureCount
+     */
+    public function setFailureCount($failureCount)
+    {
+        $this->failureCount = $failureCount;
+        return $this;
+    }
+
+    /**
+     * Get the number of tests tracked by this
+     * result.
+     *
      * @return int
      */
     public function getTestCount()
@@ -129,10 +145,37 @@ class TestResult
     }
 
     /**
+     * Set the number of tests tracked by this
+     * result.
+     *
+     * @param int $testCount
+     */
+    public function setTestCount($testCount)
+    {
+        $this->testCount = $testCount;
+        return $this;
+    }
+
+    /**
+     * Get the number of pending tests tracked
+     * by this test result.
+     *
      * @return int
      */
     public function getPendingCount()
     {
         return $this->pendingCount;
+    }
+
+    /**
+     * Set the number of pending tests tracked
+     * by this test result.
+     *
+     * @param int $pendingCount
+     */
+    public function setPendingCount($pendingCount)
+    {
+        $this->pendingCount = $pendingCount;
+        return $this;
     }
 }


### PR DESCRIPTION
Adding accessors to a few properties of this key model :)

It seemed appropriate to have setters available for this model. My use case came up in the concurrency plugin when trying to get an appropriate exit code. We currently set the exit code like this in `Command`:

```php
$result = new TestResult($this->eventEmitter);
$this->getLoader()->load($this->configuration->getPath());
$this->factory->create($this->configuration->getReporter());
$this->runner->run($result);

if ($result->getFailureCount() > 0) {
    return 1;
}

return 0;
```

This works for normal test results, but what about a different condition for a failure? This is the case in the concurrency plugin when a file loaded in a worker process contains PHP fatal errors. Since we can recover from those in a concurrent context, there is no need to let it bubble up and crash everything. However we still need a way to fail the suite. This should be as easy as:

```php
$emitter->on('error', function() {
    $failures = $this->result->getFailureCount();
    $this->result->setFailureCount(++$failures);
});
```

Just an effective way to use a simple model :)