### PR TITLE
Support definition arguments

### DIFF
--- a/specs/abstract-base-reporter.spec.php
+++ b/specs/abstract-base-reporter.spec.php
@@ -2,6 +2,7 @@
 use Evenement\EventEmitter;
 use Peridot\Configuration;
 use Peridot\Reporter\AbstractBaseReporter;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -47,7 +48,7 @@ describe('AbstractBaseReporter', function() {
             });
 
             afterEach(function() {
-                putenv('PERIDOT_TTY=');
+                putenv('PERIDOT_TTY');
             });
 
             it('should set the PERIDOT_TTY environment variable', function() {
@@ -59,6 +60,13 @@ describe('AbstractBaseReporter', function() {
                 putenv('PERIDOT_TTY=1');
                 $text = $this->reporter->color('success', 'text');
                 assert("\033[32mtext\033[39m" == $text, "colored text should have been written");
+            });
+
+            it('should not write colors when output is not a stream output', function () {
+                $output = new BufferedOutput();
+                $reporter = new TtyTestReporter(new Configuration(), $output, new EventEmitter());
+                $text = $reporter->color('success', 'text');
+                assert($text == 'text', 'should not have colored text');
             });
         });
     });

--- a/specs/context.spec.php
+++ b/specs/context.spec.php
@@ -11,6 +11,7 @@ describe('Context', function() {
         $construct->setAccessible(true);
         $construct->invoke($context);
         $this->context = $context;
+        $this->context->setEventEmitter(new \Evenement\EventEmitter());
     });
 
     describe('->addSuite()', function() {

--- a/specs/suite.spec.php
+++ b/specs/suite.spec.php
@@ -172,6 +172,31 @@ describe("Suite", function() {
             assert($file === __FILE__);
         });
     });
+
+    describe('->define()', function () {
+        beforeEach(function () {
+            $this->arg = null;
+            $that = $this;
+            $this->suite = new Suite('argument testing', function($x) use ($that) {
+                $that->arg = $x;
+            });
+            $this->suite->setEventEmitter($this->eventEmitter);
+        });
+
+        it('should call the suite definition with definition arguments', function () {
+            $this->suite->setDefinitionArguments([1]);
+            $this->suite->define();
+            assert($this->arg === 1, 'should have passed argument');
+        });
+
+        it('should emit a suite.define event', function () {
+            $this->eventEmitter->on('suite.define', function ($suite) {
+                $suite->setDefinitionArguments([1]);
+            });
+            $this->suite->define();
+            assert($this->arg === 1, 'should have set definition arguments');
+        });
+    });
 });
 
 class SuiteScope extends Scope

--- a/specs/test.spec.php
+++ b/specs/test.spec.php
@@ -79,7 +79,7 @@ describe("Test", function() {
             assert(empty($test->getScope()->log), 'test should have been skipped');
         });
 
-        context("when spec is pending", function() {
+        context("when test is pending", function() {
            it("should not execute", function() {
                $neverRan = true;
                $test = new Test('shouldnt run', function() use (&$neverRan) {
@@ -89,6 +89,18 @@ describe("Test", function() {
                $test->run(new TestResult(new EventEmitter()));
                assert($neverRan, 'pending spec should not have run');
            });
+        });
+
+        context('when definition arguments have been given', function () {
+            it('should pass arguments to test', function () {
+                $arg = null;
+                $test = new Test('should have args', function ($x) use (&$arg) {
+                    $arg = $x;
+                });
+                $test->setDefinitionArguments([1]);
+                $test->run(new TestResult(new EventEmitter()));
+                assert($arg === 1, 'should have passed argument to test');
+            });
         });
 
         context('when running setup functions', function() {

--- a/src/Console/Environment.php
+++ b/src/Console/Environment.php
@@ -3,6 +3,7 @@ namespace Peridot\Console;
 
 use Evenement\EventEmitterInterface;
 use Peridot\Core\HasEventEmitterTrait;
+use Peridot\Runner\Context;
 
 /**
  * Environment is responsible for creating necessary objects and conditions
@@ -40,6 +41,7 @@ class Environment
         $this->definition = $definition;
         $this->eventEmitter = $emitter;
         $this->options = $options;
+        $this->initializeContext($emitter);
     }
 
     /**
@@ -129,5 +131,15 @@ class Environment
     protected function wasGivenAConfigurationPath()
     {
         return isset($this->options['c']) || isset($this->options['configuration']);
+    }
+
+    /**
+     * Initialize the Context with the same event emitter as the Environment.
+     *
+     * @param EventEmitterInterface $emitter
+     */
+    protected function initializeContext(EventEmitterInterface $emitter)
+    {
+        Context::getInstance()->setEventEmitter($emitter);
     }
 }

--- a/src/Core/AbstractTest.php
+++ b/src/Core/AbstractTest.php
@@ -58,6 +58,11 @@ abstract class AbstractTest implements TestInterface
     protected $file;
 
     /**
+     * @var array
+     */
+    protected $definitionArguments = [];
+
+    /**
      * @param string   $description
      * @param callable $definition
      */
@@ -262,5 +267,26 @@ abstract class AbstractTest implements TestInterface
     {
         $this->file = $file;
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $args
+     * @return $this
+     */
+    public function setDefinitionArguments(array $args)
+    {
+        $this->definitionArguments = $args;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function getDefinitionArguments()
+    {
+        return $this->definitionArguments;
     }
 }

--- a/src/Core/Suite.php
+++ b/src/Core/Suite.php
@@ -54,6 +54,17 @@ class Suite extends AbstractTest
     }
 
     /**
+     * Execute the Suite definition.
+     *
+     * @return void
+     */
+    public function define()
+    {
+        $this->eventEmitter->emit('suite.define', [$this]);
+        call_user_func_array($this->getDefinition(), $this->getDefinitionArguments());
+    }
+
+    /**
      * Run all the specs belonging to the suite
      *
      * @param TestResult $result
@@ -61,7 +72,6 @@ class Suite extends AbstractTest
     public function run(TestResult $result)
     {
         $this->eventEmitter->emit('suite.start', [$this]);
-
         $this->eventEmitter->on('suite.halt', [$this, 'halt']);
 
         foreach ($this->tests as $test) {

--- a/src/Core/Test.php
+++ b/src/Core/Test.php
@@ -54,7 +54,7 @@ class Test extends AbstractTest
         $action = ['passTest', $this];
         try {
             $this->runSetup();
-            call_user_func($this->getDefinition());
+            call_user_func_array($this->getDefinition(), $this->getDefinitionArguments());
         } catch (Exception $e) {
             $action = ['failTest', $this, $e];
         }

--- a/src/Core/TestInterface.php
+++ b/src/Core/TestInterface.php
@@ -131,4 +131,19 @@ interface TestInterface
      * @param callable $fn
      */
     public function forEachNodeTopDown(callable $fn);
+
+    /**
+     * Set arguments to be passed to the test definition when invoked.
+     *
+     * @param array $args
+     * @return mixed
+     */
+    public function setDefinitionArguments(array $args);
+
+    /**
+     * Return an array of arguments to be passed to the test definition when invoked.
+     *
+     * @return array
+     */
+    public function getDefinitionArguments();
 }

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -214,11 +214,7 @@ abstract class AbstractBaseReporter implements ReporterInterface
             return $this->hasAnsiSupport();
         }
 
-        if (method_exists($this->output, 'getStream')) {
-            return $this->hasTty();
-        }
-
-        return false;
+        return $this->hasTty();
     }
 
     /**
@@ -279,12 +275,12 @@ abstract class AbstractBaseReporter implements ReporterInterface
      */
     private function hasTty()
     {
-        if (getenv("PERIDOT_TTY")) {
-            return true;
-        }
-
         if (! $this->output instanceof StreamOutput) {
             return false;
+        }
+
+        if (getenv("PERIDOT_TTY")) {
+            return true;
         }
 
         return $this->isTtyTerminal($this->output);

--- a/src/Runner/Context.php
+++ b/src/Runner/Context.php
@@ -1,6 +1,8 @@
 <?php
 namespace Peridot\Runner;
 
+use Evenement\EventEmitter;
+use Peridot\Core\HasEventEmitterTrait;
 use Peridot\Core\Test;
 use Peridot\Core\Suite;
 
@@ -12,6 +14,8 @@ use Peridot\Core\Suite;
  */
 final class Context
 {
+    use HasEventEmitterTrait;
+
     /**
      * @var array
      */
@@ -89,7 +93,7 @@ final class Context
 
         $this->getCurrentSuite()->addTest($suite);
         array_unshift($this->suites, $suite);
-        call_user_func($suite->getDefinition());
+        $suite->define();
         array_shift($this->suites);
 
         return $suite;
@@ -163,6 +167,7 @@ final class Context
             $suite->setPending($pending);
         }
         $suite->setFile($this->file);
+        $suite->setEventEmitter($this->getEventEmitter());
         return $suite;
     }
 }

--- a/src/Runner/Context.php
+++ b/src/Runner/Context.php
@@ -85,11 +85,8 @@ final class Context
      */
     public function addSuite($description, callable $fn, $pending = null)
     {
-        $suite = new Suite($description, $fn);
-        if ($pending !== null) {
-            $suite->setPending($pending);
-        }
-        $suite->setFile($this->file);
+        $suite = $this->createSuite($description, $fn, $pending);
+
         $this->getCurrentSuite()->addTest($suite);
         array_unshift($this->suites, $suite);
         call_user_func($suite->getDefinition());
@@ -149,5 +146,23 @@ final class Context
         }
 
         return self::$instance;
+    }
+
+    /**
+     * Create a Suite based on the state of the Context.
+     *
+     * @param $description
+     * @param callable $fn
+     * @param $pending
+     * @return Suite
+     */
+    private function createSuite($description, callable $fn, $pending)
+    {
+        $suite = new Suite($description, $fn);
+        if ($pending !== null) {
+            $suite->setPending($pending);
+        }
+        $suite->setFile($this->file);
+        return $suite;
     }
 }


### PR DESCRIPTION
`TestInterface` supports setting arguments to be called with test definitions via `getDefinitionArguments` and `setDefinitionArguments`. This should be useful for passing arguments to test or suite definitions via plugins.

Since suites generally execute early to build test trees, a new `suite.define` event has been added, and listeners receive the suite that has just been defined. This event is where to hook in for setting suite definition arguments.

For instances of `Test` - the classic `test.run` event can be used for the same purpose.

Fixes #134 