### PR TITLE
Default specs directory and move Context into Core

### DIFF
--- a/peridot.php
+++ b/peridot.php
@@ -58,7 +58,6 @@ return function(EventEmitterInterface $emitter) {
     $emitter->on('peridot.start', function(Environment $env) use (&$coverage) {
         $definition = $env->getDefinition();
         $definition->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
-        $definition->getArgument('path')->setDefault('specs');
     });
     
     /**

--- a/specs/configuration.spec.php
+++ b/specs/configuration.spec.php
@@ -15,6 +15,13 @@ describe('Configuration', function() {
         });
     });
 
+    describe('->getPath()', function () {
+        it('should default to a specs directory in the current working directory', function () {
+            $expected = getcwd() . DIRECTORY_SEPARATOR . 'specs';
+            assert($this->configuration->getPath() === $expected);
+        });
+    });
+
     describe('->setConfigurationFile()', function() {
 
         it('should check current working directory with file name', function() {

--- a/specs/context.spec.php
+++ b/specs/context.spec.php
@@ -1,11 +1,11 @@
 <?php
 
-use Peridot\Runner\Context;
+use Peridot\Core\Context;
 
 describe('Context', function() {
 
     beforeEach(function() {
-        $this->reflection = new ReflectionClass('Peridot\Runner\Context');
+        $this->reflection = new ReflectionClass('Peridot\Core\Context');
         $context = $this->reflection->newInstanceWithoutConstructor();
         $construct = $this->reflection->getConstructor();
         $construct->setAccessible(true);

--- a/specs/suiteloader.spec.php
+++ b/specs/suiteloader.spec.php
@@ -1,5 +1,5 @@
 <?php
-use Peridot\Runner\Context;
+use Peridot\Core\Context;
 use Peridot\Runner\SuiteLoader;
 
 describe("SuiteLoader", function() {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -46,7 +46,7 @@ class Configuration
 
     public function __construct()
     {
-        $this->path = getcwd();
+        $this->path = getcwd() . DIRECTORY_SEPARATOR . 'specs';
         $this->configurationFile = getcwd() . DIRECTORY_SEPARATOR . 'peridot.php';
         $this->dsl = __DIR__ . DIRECTORY_SEPARATOR . 'Dsl.php';
     }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -3,7 +3,7 @@ namespace Peridot\Console;
 
 use Peridot\Configuration;
 use Peridot\Reporter\ReporterFactory;
-use Peridot\Runner\Context;
+use Peridot\Core\Context;
 use Peridot\Runner\Runner;
 use Peridot\Runner\RunnerInterface;
 use Symfony\Component\Console\Application as ConsoleApplication;

--- a/src/Console/Environment.php
+++ b/src/Console/Environment.php
@@ -3,7 +3,7 @@ namespace Peridot\Console;
 
 use Evenement\EventEmitterInterface;
 use Peridot\Core\HasEventEmitterTrait;
-use Peridot\Runner\Context;
+use Peridot\Core\Context;
 
 /**
  * Environment is responsible for creating necessary objects and conditions

--- a/src/Core/Context.php
+++ b/src/Core/Context.php
@@ -1,5 +1,5 @@
 <?php
-namespace Peridot\Runner;
+namespace Peridot\Core;
 
 use Evenement\EventEmitter;
 use Peridot\Core\HasEventEmitterTrait;
@@ -7,10 +7,10 @@ use Peridot\Core\Test;
 use Peridot\Core\Suite;
 
 /**
- * Context tracks the state of the runner - i.e the current Suite, and provides access to
- * Peridot's global state.
+ * Context represents the state of a Peridot test hierarchy - i.e the current Suite, and provides access to
+ * Peridot's global test tree.
  *
- * @package Peridot\Runner
+ * @package Peridot\Core
  */
 final class Context
 {

--- a/src/Dsl.php
+++ b/src/Dsl.php
@@ -1,5 +1,5 @@
 <?php
-use Peridot\Runner\Context;
+use Peridot\Core\Context;
 
 /**
  * Creates a suite and sets it on the suite factory

--- a/src/Reporter/SpecReporter.php
+++ b/src/Reporter/SpecReporter.php
@@ -3,7 +3,7 @@ namespace Peridot\Reporter;
 
 use Peridot\Core\Test;
 use Peridot\Core\Suite;
-use Peridot\Runner\Context;
+use Peridot\Core\Context;
 
 /**
  * The SpecReporter is the default Peridot reporter. It organizes Suite and Test results

--- a/src/Runner/SuiteLoader.php
+++ b/src/Runner/SuiteLoader.php
@@ -1,6 +1,8 @@
 <?php
 namespace Peridot\Runner;
 
+use Peridot\Core\Context;
+
 /**
  * SuiteLoader will recursively load test files given a glob friendly
  * pattern.


### PR DESCRIPTION
The new default spec directory is `specs/` instead of the current working directory. This PR also adds Context into the Core namespace.

Fixes #130 and Fixes #145 