### PR TITLE
Added optional arg to Console\Command::getSynopsis

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -116,7 +116,7 @@ class Command extends ConsoleCommand
      *
      * @return string
      */
-    public function getSynopsis()
+    public function getSynopsis($short = false)
     {
         return $this->getName() . ' [options] [files]';
     }


### PR DESCRIPTION
This arg was recently added by Symfony because they don't understand SemVer. Since this optional argument is missing in Peridot's extending class, PHP throws a Strict Standards error.