### PR TITLE
Add --force-color option

### DIFF
--- a/specs/configuration.spec.php
+++ b/specs/configuration.spec.php
@@ -78,4 +78,14 @@ describe('Configuration', function() {
         });
     });
 
+    describe('->enableColorsExplicit()', function() {
+        it('should enable colors when explicit is set', function() {
+            $this->configuration->enableColorsExplicit();
+            $this->configuration->disableColors();
+
+            assert(getenv('PERIDOT_COLORS_ENABLED'), 'should have set colors env');
+            assert($this->configuration->areColorsEnabled(), 'should have set configuration value');
+        });
+    });
+
 });

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -129,9 +129,8 @@ class Configuration
         if ( $this->colorsEnableExplicit ) {
             return $this;
         }
-        else {
-            return $this->write('colorsEnabled', false);
-        }
+
+        return $this->write('colorsEnabled', false);
     }
 
     /**
@@ -139,8 +138,11 @@ class Configuration
      *
      * @return $this
      */
-    public function enableColorsExplicit() {
-        return $this->write('colorsEnableExplicit', true) && $this->write('colorsEnabled', true);
+    public function enableColorsExplicit()
+    {
+        return $this
+            ->write('colorsEnableExplicit', true)
+            ->write('colorsEnabled', true);
     }
 
     /**
@@ -158,7 +160,8 @@ class Configuration
      *
      * @return boolean
      */
-    public function areColorsEnabledExplicit() {
+    public function areColorsEnabledExplicit()
+    {
         return $this->colorsEnableExplicit;
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -15,6 +15,11 @@ class Configuration
     protected $colorsEnabled = true;
 
     /**
+     * @var boolean
+     */
+    protected $colorsEnableExplicit = false;
+
+    /**
      * @var string
      */
     protected $grep = '*.spec.php';
@@ -121,7 +126,21 @@ class Configuration
      */
     public function disableColors()
     {
-        return $this->write('colorsEnabled', false);
+        if ( $this->colorsEnableExplicit ) {
+            return $this;
+        }
+        else {
+            return $this->write('colorsEnabled', false);
+        }
+    }
+
+    /**
+     * Force output colors even without TTY support.
+     *
+     * @return $this
+     */
+    public function enableColorsExplicit() {
+        return $this->write('colorsEnableExplicit', true) && $this->write('colorsEnabled', true);
     }
 
     /**
@@ -131,7 +150,16 @@ class Configuration
      */
     public function areColorsEnabled()
     {
-        return $this->colorsEnabled;
+        return $this->colorsEnableExplicit || $this->colorsEnabled;
+    }
+
+    /**
+     * Check if output colors are explicitly enabled.
+     *
+     * @return boolean
+     */
+    public function areColorsEnabledExplicit() {
+        return $this->colorsEnableExplicit;
     }
 
     /**

--- a/src/Console/ConfigurationReader.php
+++ b/src/Console/ConfigurationReader.php
@@ -37,6 +37,7 @@ class ConfigurationReader
         $options = [
             'grep' => [$configuration, 'setGrep'],
             'no-colors' => [$configuration, 'disableColors'],
+            'force-colors' => [$configuration, 'enableColorsExplicit'],
             'bail' => [$configuration, 'stopOnFailure'],
             'configuration' => [$configuration, 'setConfigurationFile']
         ];

--- a/src/Console/InputDefinition.php
+++ b/src/Console/InputDefinition.php
@@ -23,6 +23,7 @@ class InputDefinition extends Definition
 
         $this->addOption(new InputOption('grep', 'g', InputOption::VALUE_REQUIRED, 'Run tests matching <pattern> <comment>(default: *.spec.php)</comment>'));
         $this->addOption(new InputOption('no-colors', 'C', InputOption::VALUE_NONE, 'Disable output colors'));
+        $this->addOption(new InputOption('--force-colors', '-f', InputOption::VALUE_NONE, 'Force output colors'));
         $this->addOption(new InputOption('reporter', 'r', InputOption::VALUE_REQUIRED, 'Select which reporter to use <comment>(default: spec)</comment>'));
         $this->addOption(new InputOption('bail', 'b', InputOption::VALUE_NONE, 'Stop on failure'));
         $this->addOption(new InputOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'A php file containing peridot configuration'));

--- a/src/Console/InputDefinition.php
+++ b/src/Console/InputDefinition.php
@@ -23,7 +23,7 @@ class InputDefinition extends Definition
 
         $this->addOption(new InputOption('grep', 'g', InputOption::VALUE_REQUIRED, 'Run tests matching <pattern> <comment>(default: *.spec.php)</comment>'));
         $this->addOption(new InputOption('no-colors', 'C', InputOption::VALUE_NONE, 'Disable output colors'));
-        $this->addOption(new InputOption('--force-colors', '-f', InputOption::VALUE_NONE, 'Force output colors'));
+        $this->addOption(new InputOption('--force-colors', null, InputOption::VALUE_NONE, 'Force output colors'));
         $this->addOption(new InputOption('reporter', 'r', InputOption::VALUE_REQUIRED, 'Select which reporter to use <comment>(default: spec)</comment>'));
         $this->addOption(new InputOption('bail', 'b', InputOption::VALUE_NONE, 'Stop on failure'));
         $this->addOption(new InputOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'A php file containing peridot configuration'));

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -102,7 +102,13 @@ abstract class AbstractBaseReporter implements ReporterInterface
      */
     public function color($key, $text)
     {
-        if (!$this->configuration->areColorsEnabled() || !$this->hasColorSupport()) {
+        if (
+            !$this->configuration->areColorsEnabledExplicit() &&
+            (
+                !$this->configuration->areColorsEnabled() ||
+                !$this->hasColorSupport()
+            )
+        ) {
             return $text;
         }
 

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -102,13 +102,10 @@ abstract class AbstractBaseReporter implements ReporterInterface
      */
     public function color($key, $text)
     {
-        if (
-            !$this->configuration->areColorsEnabledExplicit() &&
-            (
-                !$this->configuration->areColorsEnabled() ||
-                !$this->hasColorSupport()
-            )
-        ) {
+        $colorsEnabled = $this->configuration->areColorsEnabled() && $this->hasColorSupport();
+        $colorsEnabledExplicit = $this->configuration->areColorsEnabledExplicit();
+
+        if (!$colorsEnabled && !$colorsEnabledExplicit) {
             return $text;
         }
 


### PR DESCRIPTION
PR regarding #165 

The `-f` shortcut may not imply this option intuitively, but both `C` and `c` has been taken.

I have tested with apache with backtick operators and it works, but I have no way to emulate `->hasTty() === false` environment when tests are run from CLI.

I just quickly pimped it up, would def. like your comments.