### PR TITLE
spec should use getCommandName interface correctly

### DIFF
--- a/specs/application.spec.php
+++ b/specs/application.spec.php
@@ -3,6 +3,7 @@ use Peridot\Console\Application;
 use Peridot\Core\Suite;
 use Peridot\Runner\Runner;
 use Peridot\Runner\RunnerInterface;
+use Symfony\Component\Console\Input\ArgvInput;
 
 describe('Application', function() {
     include __DIR__ . '/shared/application-tester.php';
@@ -35,7 +36,8 @@ describe('Application', function() {
 
     describe('->getCommandName()', function() {
         it('should return "peridot"', function() {
-            assert($this->application->getCommandName() == "peridot", "command name should be peridot");
+            $input = new ArgvInput(['foo.php', 'bar'], $this->definition);
+            assert($this->application->getCommandName($input) == "peridot", "command name should be peridot");
         });
     });
 

--- a/specs/test-result.spec.php
+++ b/specs/test-result.spec.php
@@ -42,7 +42,8 @@ describe("TestResult", function() {
         });
 
         it('should increment the test count', function() {
-            $this->result->startTest();
+            $test = new Test('test', function () {});
+            $this->result->startTest($test);
             assert(1 === $this->result->getTestCount(), "test count should be 1");
         });
 


### PR DESCRIPTION
The `application.spec.php` spec is throwing a fatal error in PHP 7 because the test fails to pass an input interface to the method.

This PR addresses that issue.