### PR TITLE
Update Box project link to working URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Read more at [peridot-php.github.io](http://peridot-php.github.io/) or head over
 
 ##Building PHAR
 
-Peridot's phar is built using [Box](http://box-project.org/). Once box is installed, the phar can be built using
+Peridot's phar is built using [Box](https://github.com/box-project/). Once box is installed, the phar can be built using
 the following command from the project directory:
 
 ```


### PR DESCRIPTION
The Box project website (http://box-project.org) seems to have expired and been taken over by a domain squatter / auction service.  The README could use the Github project URL instead.
