### PR TITLE
Changed test typehint from AbstractTest to TestInterface.

### DIFF
--- a/src/Core/Suite.php
+++ b/src/Core/Suite.php
@@ -99,10 +99,10 @@ class Suite extends AbstractTest
     /**
      * Run a test and track its results.
      *
+     * @param TestInterface $test
      * @param TestResult $result
-     * @param $test
      */
-    protected function runTest(AbstractTest $test, TestResult $result)
+    protected function runTest(TestInterface $test, TestResult $result)
     {
         if ($this->getPending() !== null) {
             $test->setPending($this->getPending());


### PR DESCRIPTION
This PR is very simple, it allows `Suite::runTest()` to run any `TestInterface` implementation, instead of requiring tests to extend `AbstractTest`. It seems like the use of `AbstractTest` as a type hint was probably left over from a time before `TestInterface` existed.

What's more interesting, and what I can't figure out, is why this was **only** causing problems for me under PHP 7.

I have a pretty advanced use case. I am testing asynchronous code that uses [Recoil](https://github.com/recoilphp/recoil), a generator-based coroutine library. I'm using Peridot's event system to wrap every test in my own implementation of `TestInterface` that runs the test under Recoil. My Peridot configuration looks like this:

```php
// ... snip ...

class AsyncTestWrapper implements TestInterface
{
    public function __construct(TestInterface $test)
    {
        $this->test = $test;
    }

    public function run(TestResult $result)
    {
        return $this->test->run($result);
    }

    // ... snip ...

    public function getDefinition()
    {
        return function (...$arguments) {
            $definition = $this->test->getDefinition();
            $result = $definition(...$arguments);

            if ($result instanceof Generator) {
                $coroutine = $result;

                Recoil::run(function () use ($coroutine, &$result) {
                    $result = (yield $coroutine);
                });
            }

            return $result;
        };
    }

    // ... snip ...

    public function getDefinitionArguments()
    {
        return $this->test->getDefinitionArguments();
    }

    private $test;
}

return function (EventEmitterInterface $emitter) {
    $emitter->on(
        'suite.start',
        function (Suite $suite) {
            $suite->setTests(
                array_map(
                    function ($test) {
                        return new AsyncTestWrapper($test);
                    },
                    $suite->getTests()
                )
            );
        }
    );
};
```

This allows Peridot tests to become Recoil coroutines, and to use `yield` inside tests to perform asynchronous operations:

```php
it('persists the document', function () {
    expect(yield $this->subject->persistDocument($this->id, $this->document))->to->be->true();

    $this->database->write->calledWith($this->id, $this->document, null);
});
```

This is working perfectly under PHP 5.6, but under PHP 7 I get:

```
Fatal error: Uncaught TypeError: Argument 1 passed to Peridot\Core\Suite::runTest() must be an instance of Peridot\Core\AbstractTest, instance of AsyncTestWrapper given, called in /path/to/project/vendor/peridot-php/peridot/src/Core/Suite.php on line 83 and defined in /path/to/project/vendor/peridot-php/peridot/src/Core/Suite.php:105
Stack trace:
#0 /path/to/project/vendor/peridot-php/peridot/src/Core/Suite.php(83): Peridot\Core\Suite->runTest(Object(AsyncTestWrapper), Object(Peridot\Core\TestResult))
#1 /path/to/project/vendor/peridot-php/peridot/src/Runner/Runner.php(59): Peridot\Core\Suite->run(Object(Peridot\Core\TestResult))
#2 /path/to/project/vendor/peridot-php/peridot/src/Console/Command.php(176): Peridot\Runner\Runner->run(Object(Peridot\Core\TestResult))
#3 /path/to/project/vendor/peridot-php/peridot/src/Console/Command.php(149): Peridot\Console\Command->getResult()
#4 /path/to/p in /path/to/project/vendor/peridot-php/peridot/src/Core/Suite.php on line 105
```

I have absolutely no idea how it could be working under 5.6 and not under 7, but there it is. Perhaps someone with a better understanding of Peridot could come up with a simpler, reproducible regression test for this issue.

In any case, this PR makes the problem go away.