### PR TITLE
Do not suppress errors

### DIFF
--- a/specs/runner.spec.php
+++ b/specs/runner.spec.php
@@ -183,7 +183,21 @@ describe("Runner", function() {
 
         it("should emit an error event with error information", $behavesLikeErrorEmitter);
 
-        it("should restore a previous error handler", function() use ($behavesLikeErrorEmitter) {
+        it("should invoke the previous error handler on error", function() use ($behavesLikeErrorEmitter) {
+            $handled = [];
+            $handler = function() use (&$handled) {
+                $handled = func_get_args();
+            };
+            set_error_handler($handler);
+            call_user_func(Closure::bind($behavesLikeErrorEmitter, $this, $this));
+            assert(count($handled) === 4, "runner should have invoked previous handler");
+            assert($handled[0] === E_USER_NOTICE, "runner should have invoked previous handler");
+            assert($handled[1] === "This is a user notice", "runner should have invoked previous handler");
+            assert($handled[2] === __FILE__, "runner should have invoked previous handler");
+            assert(is_int($handled[3]), "runner should have invoked previous handler");
+        });
+
+        it("should restore a previous error handler upon completion", function() use ($behavesLikeErrorEmitter) {
             $handler = function($errno, $errstr, $errfile, $errline) {
                 //such errors handled. wow!
             };

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -67,8 +67,15 @@ class Runner implements RunnerInterface
      */
     protected function handleErrors()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+        $handler = null;
+        $handler = set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$handler) {
             $this->eventEmitter->emit('error', [$errno, $errstr, $errfile, $errline]);
+
+            if ($handler) {
+                return $handler($errno, $errstr, $errfile, $errline);
+            }
+
+            return false;
         });
     }
 }


### PR DESCRIPTION
I use [Asplode](https://github.com/eloquent/asplode) in my `peridot.php` to set up an error handler that converts errors into error exceptions. I only recently realised that this was not working, and that my tests were passing silently despite errors.

I see two problems here:

1. Peridot is currently overwriting and ignoring any existing error handler.
2. Peridot is currently silencing errors, because the error handler doesn't actually do anything except to raise a Peridot "error" event. That seems like a dangerous choice. Shouldn't a test fail if an error occurs during its execution, and shouldn't that happen without having to write a custom "error" event handler?

This PR addresses these two problems in the following ways:

1. If there is an existing error handler, Peridot will now "forward on" the error to the existing handler. This includes using the existing error handler's return value, which is important (see below).
2. If there is no existing error handler, Peridot's error handler will now return `false` to indicate that the error should propagate to PHP's inbuilt error handler. This means that the error will at least be displayed to the user, instead of being silenced completely.

This does not address the issue of whether tests should fail due to errors, but that's probably another discussion / PR.