### PR TITLE
Tests now fail when an error occurs.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,7 @@
 filter:
   paths: [src/*]
   excluded_paths: [vendor/*, specs/*, src/Test/*]
+  dependency_paths: [fixtures/*]
 checks:
   php:
     parameter_doc_comments: false
@@ -23,7 +24,7 @@ tools:
       method_contract_checks:
         verify_documented_constraints: false
   sensiolabs_security_checker: true
-  php_code_sniffer: 
+  php_code_sniffer:
     enabled: true
     config:
       standard: "PSR2"

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
       "Peridot\\": "src/"
     }
   },
+  "autoload-dev": {
+    "files": [
+      "fixtures/error-polyfill.php"
+    ]
+  },
   "bin": ["bin/peridot"]
 }

--- a/fixtures/error-polyfill.php
+++ b/fixtures/error-polyfill.php
@@ -1,0 +1,8 @@
+<?php
+
+if (!interface_exists('Throwable')) {
+    interface Throwable {}
+}
+if (!class_exists('Error')) {
+    class Error extends Exception implements Throwable {}
+}

--- a/specs/runner.spec.php
+++ b/specs/runner.spec.php
@@ -160,51 +160,5 @@ describe("Runner", function() {
                 assert($result->getTestCount() === 3, "spec count should be 3");
             });
         });
-
-        $behavesLikeErrorEmitter = function() {
-            $this->suite->addTest(new Test("my spec", function() {
-                trigger_error("This is a user notice", E_USER_NOTICE);
-            }));
-
-            $error = [];
-            $this->eventEmitter->on('error', function($errno, $errstr, $errfile, $errline) use (&$error) {
-                $error = array(
-                    'errno' => $errno,
-                    'errstr' => $errstr,
-                    'errfile' => $errfile,
-                    'errline' => $errline
-                );
-            });
-
-            $this->runner->run(new TestResult(new EventEmitter()));
-            assert($error['errno'] == E_USER_NOTICE, "error event should have passed error constant");
-            assert($error['errstr'] == "This is a user notice");
-        };
-
-        it("should emit an error event with error information", $behavesLikeErrorEmitter);
-
-        it("should invoke the previous error handler on error", function() use ($behavesLikeErrorEmitter) {
-            $handled = [];
-            $handler = function() use (&$handled) {
-                $handled = func_get_args();
-            };
-            set_error_handler($handler);
-            call_user_func(Closure::bind($behavesLikeErrorEmitter, $this, $this));
-            assert(count($handled) === 4, "runner should have invoked previous handler");
-            assert($handled[0] === E_USER_NOTICE, "runner should have invoked previous handler");
-            assert($handled[1] === "This is a user notice", "runner should have invoked previous handler");
-            assert($handled[2] === __FILE__, "runner should have invoked previous handler");
-            assert(is_int($handled[3]), "runner should have invoked previous handler");
-        });
-
-        it("should restore a previous error handler upon completion", function() use ($behavesLikeErrorEmitter) {
-            $handler = function($errno, $errstr, $errfile, $errline) {
-                //such errors handled. wow!
-            };
-            set_error_handler($handler);
-            call_user_func(Closure::bind($behavesLikeErrorEmitter, $this, $this));
-            $old = set_error_handler(function($n,$s,$f,$l) {});
-            assert($handler === $old, "runner should have restored previous handler");
-        });
     });
 });

--- a/specs/spec-reporter.spec.php
+++ b/specs/spec-reporter.spec.php
@@ -17,7 +17,7 @@ describe('SpecReporter', function() {
     context('when test.failed is emitted', function() {
         it('should include an error number and the test description', function() {
             $test = new Test("test", function() {});
-            $this->emitter->emit('test.failed', [$test]);
+            $this->emitter->emit('test.failed', [$test, new Exception()]);
             $contents = $this->output->fetch();
             assert(strstr($contents, '1) test') !== false, "error count and test description should be present");
         });

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -45,8 +45,6 @@ class Runner implements RunnerInterface
      */
     public function run(TestResult $result)
     {
-        $this->handleErrors();
-
         $this->eventEmitter->on('test.failed', function () {
             if ($this->configuration->shouldStopOnFailure()) {
                 $this->eventEmitter->emit('suite.halt');
@@ -58,24 +56,5 @@ class Runner implements RunnerInterface
         $start = microtime(true);
         $this->suite->run($result);
         $this->eventEmitter->emit('runner.end', [microtime(true) - $start]);
-
-        restore_error_handler();
-    }
-
-    /**
-     * Set an error handler to broadcast an error event.
-     */
-    protected function handleErrors()
-    {
-        $handler = null;
-        $handler = set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$handler) {
-            $this->eventEmitter->emit('error', [$errno, $errstr, $errfile, $errline]);
-
-            if ($handler) {
-                return $handler($errno, $errstr, $errfile, $errline);
-            }
-
-            return false;
-        });
     }
 }


### PR DESCRIPTION
Continuing from #175, this PR further improves the error handling in Peridot.

The biggest change is that when an error occurs in a test, that test will now fail. This new behavior will honor the `error_reporting` setting, meaning that systems that typically ignore errors of a given severity can still be tested under Peridot. This is the same underlying mechanism used by the error control operator (`@`), so that will also work as intended.

Regardless of the `error_reporting` level, a Peridot `error` event will still be emitted. It will be up to individual listener implementations to decide whether to honor the `error_reporting` level.

Another change is to the behavior of tests in which multiple failures occur. Previously, if a test failed AND its teardown also failed, the teardown failure would "overwrite" the test failure. This behavior has changed so that the first failure is always the failure that is reported. This has particular significance given that a test can now fail because of an error, and then continue on to fail because of an assertion failure or other exception.

I also added support for PHP 7 [engine exceptions](http://php.net/language.errors.php7). Note that I have polyfilled the existence of [Throwable](http://php.net/throwable) and [Error](http://php.net/error), so that the tests may also be run under PHP 5.

This PR *should* also solve #158 and #132.