### PR TITLE
Adds codecov support and updates build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,49 @@
 language: php
 
-php:
-  - 5.6
-  - 5.5
-  - 5.4
-  - 7
-  - hhvm
-  - hhvm-nightly
-
 matrix:
-  fast_finish: true
-  allow_failures:
-    - php: hhvm-nightly
-    - php: 7
+    include:
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+        - php: nightly
+        - php: hhvm-3.6
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-3.9
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-3.12
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-3.15
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-nightly
+          sudo: required
+          dist: trusty
+          group: edge
+    fast_finish: true
+    allow_failures:
+        - php: nightly
+        - php: hhvm-nightly
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer
 
 install:
   - composer install --prefer-source
 
 script:
-  - CODE_COVERAGE=clover bin/peridot specs/
+  - CODE_COVERAGE=clover make coverage
 
-after_script:
-  - php vendor/bin/coveralls
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+ifeq ($(TRAVIS_PHP_VERSION), nightly)
+coverage:
+	echo "Skipping coverage for nightly"
+	exit 0
+else
+coverage:
+ifndef CODE_COVERAGE
+	$(error CODE_COVERAGE is undefined)
+endif
+
+ifeq ($(TRAVIS_PHP_VERSION), $(filter $(TRAVIS_PHP_VERSION), 7.0 7.1))
+	phpdbg --version
+	phpdbg -qrr bin/peridot specs
+else
+	bin/peridot specs
+endif
+endif

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ![Peridot logo](https://raw.github.com/peridot-php/peridot/master/logo.png "Peridot logo")
 
-[![Build Status](https://travis-ci.org/peridot-php/peridot.png)](https://travis-ci.org/peridot-php/peridot) [![HHVM Status](http://hhvm.h4cc.de/badge/peridot-php/peridot.svg)](http://hhvm.h4cc.de/package/peridot-php/peridot)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/peridot-php/peridot/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/peridot-php/peridot/?branch=master)
-[![Packagist](https://img.shields.io/packagist/dt/peridot-php/peridot.svg?style=flat)](https://packagist.org/packages/peridot-php/peridot)
+[![Build Status](https://img.shields.io/travis/peridot-php/peridot/master.svg?style=flat-square)](https://travis-ci.org/peridot-php/peridot) [![HHVM Status](https://img.shields.io/badge/hhvm-tested-brightgreen.svg?style=flat-square)](http://hhvm.h4cc.de/package/peridot-php/peridot)
+[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/peridot-php/peridot.svg?style=flat-square)](https://scrutinizer-ci.com/g/peridot-php/peridot/?branch=master)
+[![Packagist](https://img.shields.io/packagist/dt/peridot-php/peridot.svg?style=flat-square)](https://packagist.org/packages/peridot-php/peridot)
+[![codecov](https://img.shields.io/codecov/c/github/peridot-php/peridot/master.svg?style=flat-square)](https://codecov.io/gh/peridot-php/peridot)
 
 The highly extensible, highly enjoyable, PHP testing framework.
 

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,13 @@
   "require": {
     "php": ">=5.4.0",
     "evenement/evenement": "2.0.*",
-    "symfony/console": "~2.0|~3.0",
-    "phpunit/php-timer": "~1.0",
-    "peridot-php/peridot-scope": "~1.0"
+    "symfony/console": "^2.0|^3.0",
+    "phpunit/php-timer": "^1.0",
+    "peridot-php/peridot-scope": "^1.0"
   },
   "require-dev": {
-    "codegyre/robo": "~0.4",
-    "phpunit/php-code-coverage": "~2.0",
-    "satooshi/php-coveralls": "~0.6"
+    "codegyre/robo": "^0.4",
+    "phpunit/php-code-coverage": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/peridot.php
+++ b/peridot.php
@@ -22,13 +22,13 @@ return function(EventEmitterInterface $emitter) {
 
     $codeCoverage = getenv('CODE_COVERAGE');
     $hhvm = defined('HHVM_VERSION'); //exclude coverage from hhvm because its pretty flawed at the moment
-    $php7 = preg_match('/^7/', PHP_VERSION);
-    $shouldCover = !$hhvm && $php7 == 0;
+    $shouldCover = !$hhvm;
 
     if ($codeCoverage == 'html' && $shouldCover) {
         $coverage = new PHP_CodeCoverage();
         $emitter->on('runner.start', function() use ($coverage) {
-            $coverage->filter()->addFileToBlacklist(__DIR__. '/src/Dsl.php');
+            $coverage->filter()->addDirectoryToWhitelist(__DIR__ . '/src');
+            $coverage->filter()->removeFileFromWhitelist(__DIR__ . '/src/Dsl.php');
             $coverage->start('peridot');
         });
 
@@ -42,7 +42,8 @@ return function(EventEmitterInterface $emitter) {
     if ($codeCoverage == 'clover' && $shouldCover) {
         $coverage = new PHP_CodeCoverage();
         $emitter->on('runner.start', function() use ($coverage) {
-            $coverage->filter()->addFileToBlacklist(__DIR__. '/src/Dsl.php');
+            $coverage->filter()->addDirectoryToWhitelist(__DIR__ . '/src');
+            $coverage->filter()->removeFileFromWhitelist(__DIR__ . '/src/Dsl.php');
             $coverage->start('peridot');
         });
 
@@ -60,7 +61,7 @@ return function(EventEmitterInterface $emitter) {
         $definition->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
         $definition->getArgument('path')->setDefault('specs');
     });
-    
+
     /**
      * Demonstrate registering a custom reporter via peridot config
      */


### PR DESCRIPTION
Switches us over to using codecov

@ezzatron - I took a cue from you and introduced a Makefile. codecov says it aggregates reports across builds, so I thought it would be good to let code coverage run for all build targets in the matrix (with the exception of allowed failures)

The Makefile currently only defines a `coverage` target, but we can define more for other build tasks as we need them. 

The `coverage` target is conditionally defined to skip nightly builds and to use `phpdbg` for PHP 7.0 and 7.1 (as it is the only driver supported for those versions with our version of `phpunit/php-code-coverage`)