### PR TITLE
[WIP] Implement --focus and --skip CLI options

### DIFF
--- a/specs/configuration-reader.spec.php
+++ b/specs/configuration-reader.spec.php
@@ -9,6 +9,8 @@ describe('ConfigurationReader', function() {
     beforeEach(function() {
         $this->definition = array(
             'path' => 'mypath',
+            '--focus' => '/focus/',
+            '--skip' => '/skip/',
             '--grep' => 'mygrep',
             '--no-colors' => true,
             '--bail' => true,
@@ -17,6 +19,8 @@ describe('ConfigurationReader', function() {
         $this->input = new ArrayInput($this->definition, new InputDefinition());
         $this->assert = function($config) {
             assert($config->getPath() == "mypath", "path should be mypath");
+            assert($config->getFocusPattern() == '/focus/', 'focus pattern should be /focus/');
+            assert($config->getSkipPattern() == '/skip/', 'skip pattern should be /skip/');
             assert($config->getGrep() == "mygrep", "grep should be mygrep");
             assert(!$config->areColorsEnabled(), "colors should be disabled");
             assert($config->shouldStopOnFailure(), "should stop on failure");

--- a/specs/configuration.spec.php
+++ b/specs/configuration.spec.php
@@ -84,6 +84,46 @@ describe('Configuration', function() {
         });
     });
 
+    describe('->setFocusPattern()', function() {
+        it('should normalize patterns that are invalid regular expressions', function() {
+            $this->configuration->setFocusPattern('certain ~( type of)? test');
+            $pattern = $this->configuration->getFocusPattern();
+
+            assert(preg_match($pattern, 'certain ~ test'), 'normalized pattern should still honor PCRE syntax');
+            assert(preg_match($pattern, 'certain ~ type of test'), 'normalized pattern should still honor PCRE syntax');
+            assert(preg_match($pattern, 'a certain ~ test with extras'), 'normalized pattern should match text with prefixes and suffixes');
+            assert(!preg_match($pattern, 'an uncertain ~ test'), 'normalized pattern should not match text without word boundaries');
+        });
+
+        it('should fall back to plaintext matching for regular expressions that cannot be salvaged', function() {
+            $this->configuration->setFocusPattern('lol(wat');
+            $pattern = $this->configuration->getFocusPattern();
+
+            assert(preg_match($pattern, 'lmao lol(wat huh'), 'normalized pattern should match text with prefixes and suffixes');
+            assert(!preg_match($pattern, 'lolol(wat'), 'normalized pattern should not match text without word boundaries');
+        });
+    });
+
+    describe('->setSkipPattern()', function() {
+        it('should normalize patterns that are invalid regular expressions', function() {
+            $this->configuration->setSkipPattern('certain ~( type of)? test');
+            $pattern = $this->configuration->getSkipPattern();
+
+            assert(preg_match($pattern, 'certain ~ test'), 'normalized pattern should still honor PCRE syntax');
+            assert(preg_match($pattern, 'certain ~ type of test'), 'normalized pattern should still honor PCRE syntax');
+            assert(preg_match($pattern, 'a certain ~ test with extras'), 'normalized pattern should match text with prefixes and suffixes');
+            assert(!preg_match($pattern, 'an uncertain ~ test'), 'normalized pattern should not match text without word boundaries');
+        });
+
+        it('should fall back to plaintext matching for regular expressions that cannot be salvaged', function() {
+            $this->configuration->setSkipPattern('lol(wat');
+            $pattern = $this->configuration->getSkipPattern();
+
+            assert(preg_match($pattern, 'lmao lol(wat huh'), 'normalized pattern should match text with prefixes and suffixes');
+            assert(!preg_match($pattern, 'lolol(wat'), 'normalized pattern should not match text without word boundaries');
+        });
+    });
+
     describe('->enableColorsExplicit()', function() {
         it('should enable colors when explicit is set', function() {
             $this->configuration->enableColorsExplicit();

--- a/specs/configuration.spec.php
+++ b/specs/configuration.spec.php
@@ -52,6 +52,8 @@ describe('Configuration', function() {
 
     describe('setters', function () {
         it('should write corresponding peridot environment variables', function () {
+            $this->configuration->setFocusPattern('/focus/');
+            $this->configuration->setSkipPattern('/skip/');
             $this->configuration->setGrep('*.test.php');
             $this->configuration->setReporter('reporter');
             $this->configuration->setPath('/tests');
@@ -60,6 +62,8 @@ describe('Configuration', function() {
             $this->configuration->setDsl(__FILE__);
             $this->configuration->setConfigurationFile(__FILE__);
 
+            $focusPattern = getenv('PERIDOT_FOCUS_PATTERN');
+            $skipPattern = getenv('PERIDOT_SKIP_PATTERN');
             $grep = getenv('PERIDOT_GREP');
             $reporter = getenv('PERIDOT_REPORTER');
             $path = getenv('PERIDOT_PATH');
@@ -68,6 +72,8 @@ describe('Configuration', function() {
             $dsl = getenv('PERIDOT_DSL');
             $file = getenv('PERIDOT_CONFIGURATION_FILE');
 
+            assert($focusPattern === '/focus/', 'should have set focus pattern env');
+            assert($skipPattern === '/skip/', 'should have set skip pattern env');
             assert($grep === '*.test.php', 'should have set grep env');
             assert($reporter === 'reporter', 'should have set reporter env');
             assert($path === '/tests', 'should have set path env');

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -95,7 +95,7 @@ class Configuration
      */
     public function setFocusPattern($pattern)
     {
-        return $this->write('focusPattern', $pattern);
+        return $this->write('focusPattern', $this->normalizeRegexPattern($pattern));
     }
 
     /**
@@ -116,7 +116,7 @@ class Configuration
      */
     public function setSkipPattern($pattern)
     {
-        return $this->write('skipPattern', $pattern);
+        return $this->write('skipPattern', $this->normalizeRegexPattern($pattern));
     }
 
     /**
@@ -306,5 +306,26 @@ class Configuration
         $env = 'PERIDOT_' . strtoupper(join('_', $parts));
         putenv($env . '=' . $value);
         return $this;
+    }
+
+    /**
+     * Normalize the supplied regular expression pattern.
+     *
+     * @param string $pattern
+     * @return string
+     */
+    protected function normalizeRegexPattern($pattern)
+    {
+        if (false !== @preg_match($pattern, null)) {
+            return $pattern;
+        }
+
+        $boundedPattern = '~\b' . str_replace('~', '\~', $pattern) . '\b~';
+
+        if (false !== @preg_match($boundedPattern, null)) {
+            return $boundedPattern;
+        }
+
+        return '~\b' . preg_quote($pattern, '~') . '\b~';
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -20,6 +20,16 @@ class Configuration
     protected $colorsEnableExplicit = false;
 
     /**
+     * @var string|null
+     */
+    protected $focusPattern;
+
+    /**
+     * @var string|null
+     */
+    protected $skipPattern;
+
+    /**
      * @var string
      */
     protected $grep = '*.spec.php';
@@ -75,6 +85,48 @@ class Configuration
     public function getGrep()
     {
         return $this->grep;
+    }
+
+    /**
+     * Set the pattern used to focus tests
+     *
+     * @param string|null $pattern
+     * @return $this
+     */
+    public function setFocusPattern($pattern)
+    {
+        return $this->write('focusPattern', $pattern);
+    }
+
+    /**
+     * Returns the pattern used to focus tests
+     *
+     * @return string|null
+     */
+    public function getFocusPattern()
+    {
+        return $this->focusPattern;
+    }
+
+    /**
+     * Set the pattern used to skip tests
+     *
+     * @param string|null $pattern
+     * @return $this
+     */
+    public function setSkipPattern($pattern)
+    {
+        return $this->write('skipPattern', $pattern);
+    }
+
+    /**
+     * Returns the pattern used to skip tests
+     *
+     * @return string|null
+     */
+    public function getSkipPattern()
+    {
+        return $this->skipPattern;
     }
 
     /**

--- a/src/Console/ConfigurationReader.php
+++ b/src/Console/ConfigurationReader.php
@@ -35,6 +35,8 @@ class ConfigurationReader
         $configuration = new Configuration();
 
         $options = [
+            'focus' => [$configuration, 'setFocusPattern'],
+            'skip' => [$configuration, 'setSkipPattern'],
             'grep' => [$configuration, 'setGrep'],
             'no-colors' => [$configuration, 'disableColors'],
             'force-colors' => [$configuration, 'enableColorsExplicit'],

--- a/src/Console/InputDefinition.php
+++ b/src/Console/InputDefinition.php
@@ -21,7 +21,9 @@ class InputDefinition extends Definition
         parent::__construct([]);
         $this->addArgument(new InputArgument('path', InputArgument::OPTIONAL, 'The path to a directory or file containing specs'));
 
-        $this->addOption(new InputOption('grep', 'g', InputOption::VALUE_REQUIRED, 'Run tests matching <pattern> <comment>(default: *.spec.php)</comment>'));
+        $this->addOption(new InputOption('focus', 'f', InputOption::VALUE_REQUIRED, 'Run tests matching <pattern>'));
+        $this->addOption(new InputOption('skip', 's', InputOption::VALUE_REQUIRED, 'Skip tests matching <pattern>'));
+        $this->addOption(new InputOption('grep', 'g', InputOption::VALUE_REQUIRED, 'Run tests with filenames matching <pattern> <comment>(default: *.spec.php)</comment>'));
         $this->addOption(new InputOption('no-colors', 'C', InputOption::VALUE_NONE, 'Disable output colors'));
         $this->addOption(new InputOption('--force-colors', null, InputOption::VALUE_NONE, 'Force output colors'));
         $this->addOption(new InputOption('reporter', 'r', InputOption::VALUE_REQUIRED, 'Select which reporter to use <comment>(default: spec)</comment>'));

--- a/src/Core/AbstractTest.php
+++ b/src/Core/AbstractTest.php
@@ -182,6 +182,30 @@ abstract class AbstractTest implements TestInterface
     }
 
     /**
+     * Set the focused status of the test and its children according to the
+     * supplied focus pattern and/or skip pattern
+     *
+     * @param string|null $focusPattern
+     * @param string|null $skipPattern
+     */
+    public function applyFocusPatterns($focusPattern, $skipPattern = null)
+    {
+        $title = $this->getTitle();
+
+        if ($skipPattern !== null && preg_match($skipPattern, $title)) {
+            $this->focused = false;
+
+            return;
+        }
+
+        if ($focusPattern === null) {
+            $this->focused = true;
+        } else {
+            $this->focused = (bool) preg_match($focusPattern, $title);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return array

--- a/src/Core/Suite.php
+++ b/src/Core/Suite.php
@@ -43,6 +43,22 @@ class Suite extends AbstractTest
     }
 
     /**
+     * Set the focused status of the test and its children according to the
+     * supplied focus pattern and/or skip pattern
+     *
+     * @param string|null $focusPattern
+     * @param string|null $skipPattern
+     */
+    public function applyFocusPatterns($focusPattern, $skipPattern = null)
+    {
+        parent::applyFocusPatterns($focusPattern, $skipPattern);
+
+        foreach ($this->tests as $test) {
+            $test->applyFocusPatterns($focusPattern, $skipPattern);
+        }
+    }
+
+    /**
      * Add a test to the suite
      *
      * @param Test $test

--- a/src/Core/TestInterface.php
+++ b/src/Core/TestInterface.php
@@ -97,6 +97,15 @@ interface TestInterface
     public function isFocused();
 
     /**
+     * Set the focused status of the test and its children according to the
+     * supplied focus pattern and/or skip pattern
+     *
+     * @param string|null $focusPattern
+     * @param string|null $skipPattern
+     */
+    public function applyFocusPatterns($focusPattern, $skipPattern = null);
+
+    /**
      * Return scope for this test. Scope contains instance variables
      * for a spec
      *

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -45,6 +45,13 @@ class Runner implements RunnerInterface
      */
     public function run(TestResult $result)
     {
+        $focusPattern = $this->configuration->getFocusPattern();
+        $skipPattern = $this->configuration->getSkipPattern();
+
+        if ($focusPattern !== null || $skipPattern !== null) {
+            $this->suite->applyFocusPatterns($focusPattern, $skipPattern);
+        }
+
         $this->eventEmitter->on('test.failed', function () {
             if ($this->configuration->shouldStopOnFailure()) {
                 $this->eventEmitter->emit('suite.halt');


### PR DESCRIPTION
@brianium Here's a working prototype of the `--focus` and `--skip` CLI options.

In its current form, it works like Ginkgo, in that if you specify either option on the command line, it completely overrides any tests that are focused "programatically" with an `f` prefix. Seems like the approach that will cause the least confusion.

Definitely not perfect, and no tests yet, but hopefully it's a starting point for discussion :)