### PR TITLE
[WIP] Support for multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- **[BC BREAK]** Support for specifying multiple paths via command line
+  arguments ([#200])
 - **[NEW]** Introduced focused specs for powerful test isolation ([#199],
   [#204], [#197], [#194], [#188], [#185], [#181])
 - **[IMPROVED]** Stack trace output now excludes irrelevant information ([#203],
@@ -19,6 +21,7 @@
 [#197]: https://github.com/peridot-php/peridot/pull/197
 [#198]: https://github.com/peridot-php/peridot/pull/198
 [#199]: https://github.com/peridot-php/peridot/pull/199
+[#200]: https://github.com/peridot-php/peridot/pull/200
 [#201]: https://github.com/peridot-php/peridot/pull/201
 [#203]: https://github.com/peridot-php/peridot/pull/203
 [#204]: https://github.com/peridot-php/peridot/pull/204

--- a/peridot.php
+++ b/peridot.php
@@ -59,7 +59,6 @@ return function(EventEmitterInterface $emitter) {
     $emitter->on('peridot.start', function(Environment $env) use (&$coverage) {
         $definition = $env->getDefinition();
         $definition->option("banner", null, InputOption::VALUE_REQUIRED, "Custom banner text");
-        $definition->getArgument('path')->setDefault('specs');
     });
 
     /**

--- a/specs/command.spec.php
+++ b/specs/command.spec.php
@@ -108,7 +108,7 @@ describe('Command', function() {
                 $test = new Test('fail', function() { throw new Exception('fail'); });
                 $suite->addTest($test);
                 $runner = new Runner($suite, $this->configuration, $this->emitter);
-                $command = new Command($runner, $this->configuration, $this->factory, $this->emitter);
+                $command = new Command($runner, $this->configuration, $this->factory, $this->emitter, $this->definition);
                 $command->setApplication($this->application);
                 $exit = $command->run(new ArrayInput([], $this->definition), $this->output);
 
@@ -122,7 +122,7 @@ describe('Command', function() {
                 $test = new Test('focused', function() {}, true);
                 $suite->addTest($test);
                 $runner = new Runner($suite, $this->configuration, $this->emitter);
-                $command = new Command($runner, $this->configuration, $this->factory, $this->emitter);
+                $command = new Command($runner, $this->configuration, $this->factory, $this->emitter, $this->definition);
                 $command->setApplication($this->application);
                 $exit = $command->run(new ArrayInput([], $this->definition), $this->output);
 

--- a/specs/configuration-reader.spec.php
+++ b/specs/configuration-reader.spec.php
@@ -7,8 +7,8 @@ use Symfony\Component\Console\Input\ArrayInput;
 describe('ConfigurationReader', function() {
 
     beforeEach(function() {
-        $this->definition = array(
-            'path' => 'mypath',
+        $this->argv = array(
+            'path' => ['mypath-a', 'mypath-b'],
             '--focus' => '/focus/',
             '--skip' => '/skip/',
             '--grep' => 'mygrep',
@@ -16,15 +16,16 @@ describe('ConfigurationReader', function() {
             '--bail' => true,
             '--configuration' => __FILE__
         );
-        $this->input = new ArrayInput($this->definition, new InputDefinition());
+        $this->input = new ArrayInput($this->argv, new InputDefinition());
         $this->assert = function($config) {
-            assert($config->getPath() == "mypath", "path should be mypath");
-            assert($config->getFocusPattern() == '/focus/', 'focus pattern should be /focus/');
-            assert($config->getSkipPattern() == '/skip/', 'skip pattern should be /skip/');
-            assert($config->getGrep() == "mygrep", "grep should be mygrep");
+            assert($config->getPath() === "mypath-a", "path should be mypath-a");
+            assert($config->getPaths() === ['mypath-a', 'mypath-b'], "paths should be mypath-a:mypath-b");
+            assert($config->getFocusPattern() === '/focus/', 'focus pattern should be /focus/');
+            assert($config->getSkipPattern() === '/skip/', 'skip pattern should be /skip/');
+            assert($config->getGrep() === "mygrep", "grep should be mygrep");
             assert(!$config->areColorsEnabled(), "colors should be disabled");
             assert($config->shouldStopOnFailure(), "should stop on failure");
-            assert($config->getConfigurationFile() == __FILE__, "config should be current file");
+            assert($config->getConfigurationFile() === __FILE__, "config should be current file");
         };
     });
 
@@ -37,8 +38,8 @@ describe('ConfigurationReader', function() {
         });
 
         it("should throw an exception if configuration is specified but does not exist", function() {
-            $this->definition['--configuration'] = '/path/to/nope.php';
-            $input = new ArrayInput($this->definition, new InputDefinition());
+            $this->argv['--configuration'] = '/path/to/nope.php';
+            $input = new ArrayInput($this->argv, new InputDefinition());
             $reader = new ConfigurationReader($input);
             $exception = null;
             try {
@@ -47,6 +48,29 @@ describe('ConfigurationReader', function() {
                 $exception = $e;
             }
             assert(!is_null($exception), "exception should not be null");
+        });
+
+        it('should filter defaulted paths by existence', function() {
+            unset($this->argv['path']);
+            $definition = new InputDefinition();
+            $definition->getArgument('path')->setDefault([__FILE__, __DIR__, 'nonexistent', 'nonexistent-b']);
+            $input = new ArrayInput($this->argv, $definition);
+            $reader = new ConfigurationReader($input);
+            $config = $reader->read();
+            assert($config->getPath() === __FILE__, "path should be __FILE__");
+            assert($config->getPaths() === [__FILE__, __DIR__], "paths should be [__FILE__, __DIR__]");
+        });
+
+        it('should fall back to the working directory if no default paths exist', function() {
+            unset($this->argv['path']);
+            $definition = new InputDefinition();
+            $definition->getArgument('path')->setDefault(['nonexistent-a', 'nonexistent-b']);
+            $input = new ArrayInput($this->argv, $definition);
+            $reader = new ConfigurationReader($input);
+            $config = $reader->read();
+            $cwd = getcwd();
+            assert($config->getPath() === $cwd, "path should be current file");
+            assert($config->getPaths() === [$cwd], "paths should contain current file only");
         });
 
     });

--- a/specs/configuration.spec.php
+++ b/specs/configuration.spec.php
@@ -56,7 +56,7 @@ describe('Configuration', function() {
             $this->configuration->setSkipPattern('/skip/');
             $this->configuration->setGrep('*.test.php');
             $this->configuration->setReporter('reporter');
-            $this->configuration->setPath('/tests');
+            $this->configuration->setPaths(['/tests-a', '/tests-b']);
             $this->configuration->disableColors();
             $this->configuration->stopOnFailure();
             $this->configuration->setDsl(__FILE__);
@@ -67,6 +67,7 @@ describe('Configuration', function() {
             $grep = getenv('PERIDOT_GREP');
             $reporter = getenv('PERIDOT_REPORTER');
             $path = getenv('PERIDOT_PATH');
+            $paths = getenv('PERIDOT_PATHS');
             $colors = getenv('PERIDOT_COLORS_ENABLED');
             $stop = getenv('PERIDOT_STOP_ON_FAILURE');
             $dsl = getenv('PERIDOT_DSL');
@@ -76,7 +77,8 @@ describe('Configuration', function() {
             assert($skipPattern === '/skip/', 'should have set skip pattern env');
             assert($grep === '*.test.php', 'should have set grep env');
             assert($reporter === 'reporter', 'should have set reporter env');
-            assert($path === '/tests', 'should have set path env');
+            assert($path === '/tests-a', 'should have set path env');
+            assert($paths === '/tests-a' . PATH_SEPARATOR . '/tests-b', 'should have set paths env');
             assert(!$colors, 'should have set colors env');
             assert($stop, 'should have set stop env');
             assert($dsl === __FILE__, 'should have set dsl env');
@@ -121,6 +123,34 @@ describe('Configuration', function() {
 
             assert(preg_match($pattern, 'lmao lol(wat huh'), 'normalized pattern should match text with prefixes and suffixes');
             assert(!preg_match($pattern, 'lolol(wat'), 'normalized pattern should not match text without word boundaries');
+        });
+    });
+
+    describe('->setPath()', function() {
+        it('should set both path and paths', function() {
+            $this->configuration->setPath('/tests');
+
+            assert($this->configuration->getPath() === '/tests', 'should have set path');
+            assert($this->configuration->getPaths() === ['/tests'], 'should have set paths');
+        });
+    });
+
+    describe('->setPaths()', function() {
+        it('should set both path and paths', function() {
+            $this->configuration->setPaths(['/tests-a', '/tests-b']);
+
+            assert($this->configuration->getPath() === '/tests-a', 'should have set path');
+            assert($this->configuration->getPaths() === ['/tests-a', '/tests-b'], 'should have set paths');
+        });
+
+        it('should disallow setting an empty paths array', function() {
+            $exception = null;
+            try {
+                $this->configuration->setPaths([]);
+            } catch (InvalidArgumentException $e) {
+                $exception = $e;
+            }
+            assert(!is_null($exception), 'expected exception to be thrown');
         });
     });
 

--- a/specs/input-definition.spec.php
+++ b/specs/input-definition.spec.php
@@ -8,13 +8,6 @@ describe('InputDefinition', function() {
         $this->definition = new InputDefinition();
     });
 
-    describe('->argument()', function() {
-        it('should add an argument to the definition', function() {
-            $this->definition->argument('myarg', InputArgument::OPTIONAL, 'an arg');
-            assert(!is_null($this->definition->getArgument('myarg')), 'argument() should register argument');
-        });
-    });
-
     describe('->option()', function() {
         it('should add an option to the definition', function() {
             $this->definition->option('myopt','-m', InputOption::VALUE_NONE, 'an opt');

--- a/specs/shared/application-tester.php
+++ b/specs/shared/application-tester.php
@@ -26,6 +26,6 @@ beforeEach(function() {
     $this->environment = new Environment($this->definition, $this->emitter, ['c' => $this->configPath]);
     $this->application = new Application($this->environment);
 
-    $this->command = new Command($this->runner, $this->configuration, $this->factory, $this->emitter);
+    $this->command = new Command($this->runner, $this->configuration, $this->factory, $this->emitter, $this->definition);
     $this->command->setApplication($this->application);
 });

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -40,9 +40,9 @@ class Configuration
     protected $reporter = 'spec';
 
     /**
-     * @var string
+     * @var array
      */
-    protected $path;
+    protected $paths;
 
     /**
      * @var string
@@ -61,7 +61,7 @@ class Configuration
 
     public function __construct()
     {
-        $this->path = getcwd();
+        $this->paths = [getcwd()];
         $this->configurationFile = getcwd() . DIRECTORY_SEPARATOR . 'peridot.php';
         $this->dsl = __DIR__ . DIRECTORY_SEPARATOR . 'Dsl.php';
     }
@@ -158,7 +158,7 @@ class Configuration
      */
     public function setPath($path)
     {
-        return $this->write('path', $path);
+        return $this->writePaths([$path]);
     }
 
     /**
@@ -168,7 +168,32 @@ class Configuration
      */
     public function getPath()
     {
-        return $this->path;
+        return $this->paths[0];
+    }
+
+    /**
+     * Set the paths to load tests from
+     *
+     * @param array $paths
+     * @return $this
+     */
+    public function setPaths(array $paths)
+    {
+        if (empty($paths)) {
+            throw new \InvalidArgumentException('Paths cannot be empty.');
+        }
+
+        return $this->writePaths($paths);
+    }
+
+    /**
+     * Return the paths being searched for tests
+     *
+     * @return array
+     */
+    public function getPaths()
+    {
+        return $this->paths;
     }
 
     /**
@@ -295,8 +320,8 @@ class Configuration
      * Write a configuration value and persist it to the current
      * environment.
      *
-     * @param $varName
-     * @param $value
+     * @param string $varName
+     * @param string $value
      * @return $this
      */
     protected function write($varName, $value)
@@ -305,6 +330,20 @@ class Configuration
         $parts = preg_split('/(?=[A-Z])/', $varName);
         $env = 'PERIDOT_' . strtoupper(join('_', $parts));
         putenv($env . '=' . $value);
+        return $this;
+    }
+
+    /**
+     * Write the paths and persist them to the current environment.
+     *
+     * @param array $paths
+     * @return $this
+     */
+    protected function writePaths(array $paths)
+    {
+        $this->paths = $paths;
+        putenv('PERIDOT_PATH=' . $paths[0]);
+        putenv('PERIDOT_PATHS=' . implode(PATH_SEPARATOR, $paths));
         return $this;
     }
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -48,18 +48,21 @@ class Command extends ConsoleCommand
      * @param Configuration $configuration
      * @param ReporterFactory $factory
      * @param EventEmitterInterface $eventEmitter
+     * @param InputDefinition $definition
      */
     public function __construct(
         RunnerInterface $runner,
         Configuration $configuration,
         ReporterFactory $factory,
-        EventEmitterInterface $eventEmitter
+        EventEmitterInterface $eventEmitter,
+        InputDefinition $definition
     ) {
         parent::__construct('peridot');
         $this->runner = $runner;
         $this->configuration = $configuration;
         $this->factory = $factory;
         $this->eventEmitter = $eventEmitter;
+        $this->setDefinition($definition);
     }
 
     /**
@@ -170,7 +173,10 @@ class Command extends ConsoleCommand
     protected function getResult()
     {
         $result = new TestResult($this->eventEmitter);
-        $this->getLoader()->load($this->configuration->getPath());
+        $loader = $this->getLoader();
+        foreach ($this->configuration->getPaths() as $path) {
+            $loader->load($path);
+        }
         $this->factory->create($this->configuration->getReporter());
         $this->runner->run($result);
 

--- a/src/Console/InputDefinition.php
+++ b/src/Console/InputDefinition.php
@@ -19,7 +19,7 @@ class InputDefinition extends Definition
     public function __construct()
     {
         parent::__construct([]);
-        $this->addArgument(new InputArgument('path', InputArgument::OPTIONAL, 'The path to a directory or file containing specs'));
+        $this->addArgument(new InputArgument('path', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The path to a directory or file containing specs', ['spec', 'specs', 'test', 'tests']));
 
         $this->addOption(new InputOption('focus', 'f', InputOption::VALUE_REQUIRED, 'Run tests matching <pattern>'));
         $this->addOption(new InputOption('skip', 's', InputOption::VALUE_REQUIRED, 'Skip tests matching <pattern>'));
@@ -32,23 +32,6 @@ class InputDefinition extends Definition
         $this->addOption(new InputOption('reporters', null, InputOption::VALUE_NONE, 'List all available reporters'));
         $this->addOption(new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display the Peridot version number'));
         $this->addOption(new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message.'));
-    }
-
-    /**
-     * Add an argument
-     *
-     * @param  string $name
-     * @param  null          $mode
-     * @param  string        $description
-     * @param  null          $default
-     * @return InputDefinition
-     */
-    public function argument($name, $mode = null, $description = '', $default = null)
-    {
-        $argument = new InputArgument($name, $mode, $description, $default);
-        $this->addArgument($argument);
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR adds support for specifying multiple paths as command line arguments to the `peridot` executable.

Summary/justification of changes:

- This is a BC break, because previously plugins could define additional CLI **arguments**, and having an array argument makes that impossible.
  - The docs mention this for the `peridot.start` event: "Useful for defining additional CLI arguments and options.", and will need to be updated.
  - Plugins will still be able to define CLI **options**.
  - Because of this `InputDefinition::argument()` is gone.
  - Perhaps if really necessary we could allow prefixed arguments? Probably not worth it.
- Retains support for `getPath()` and `setPath()`.
  - We can deprecate them with the next major release, and remove them in the one after that. I'm not sure how we want to handle deprecations though.
- I'm not sure what the `PERIDOT_PATH` environment variable is used for, but I also retained support for it, and added a similar `PERIDOT_PATHS` environment variable, which contains all the paths, separated by `PATH_SEPARATOR`.
- Added a default set of paths (`spec`, `specs`, `test`, `tests`).
  - This helps simplify the common case of running specs from a project's root.
  - It also gets rid of the need to specify this path in `peridot.php` config, and less config = more better.
  - If a path is explicitly specified, it is an error for it to not exist, but default paths are allowed to not exist. This matches the behavior of PHPUnit and Mocha. **EDIT:** This unfortunately requires reflection h4x, because of a limited Symfony Console interface.
- Another BC issue is setting the default path in `peridot.php` like [this](https://github.com/peridot-php/peridot-jumpstart/blob/a87b92f/peridot.php#L23).
  - This can still be done, but the default value needs to be an array.
  - `peridot-jumpstart` should be updated to remove this line, since there will be default paths out of the box.
- I had to shuffle around some input definition stuff to fix an issue with using `peridot --help`.
- <del>Symfony's built-in CLI options seem to be bugged, despite appearing in `--help` output. I'm not sure if this is an existing problem or something I've introduced.</del> **EDIT:** Fixed.