### PR TITLE
Improved stack trace output

### DIFF
--- a/fixtures/exception-trimming.spec.php
+++ b/fixtures/exception-trimming.spec.php
@@ -1,0 +1,33 @@
+<?php
+namespace Some\Really\Long\Name\That\Looks\Dumb;
+
+describe('Exception trimming', function () {
+    it('should not display irrelevent stack frames', function () {
+        new SomeClass();
+    });
+
+    it('should render assertion exceptions', function () {
+        assert('true === false', 'should implode the universe');
+    });
+});
+
+class SomeClass
+{
+    public function __construct()
+    {
+        someFunction();
+    }
+}
+
+function someFunction()
+{
+    new SomeOtherClass();
+}
+
+class SomeOtherClass
+{
+    public function __construct()
+    {
+        throw new \Exception('You done goofed.');
+    }
+}

--- a/specs/assert-exception.spec.php
+++ b/specs/assert-exception.spec.php
@@ -1,0 +1,31 @@
+<?php
+
+use Peridot\AssertException;
+
+describe('AssertException', function () {
+    context('::handle()', function () {
+        it('should throw an exception', function () {
+            $exception = null;
+            try {
+                AssertException::handle('/path/to/file', 111, '', 'You done goofed.');
+            } catch (AssertException $e) {
+                $exception = $e;
+            }
+            assert(!is_null($exception), 'exception should have been thrown');
+            assert($exception->getFile() === '/path/to/file', 'exception should have the correct filename');
+            assert($exception->getLine() === 111, 'exception should have the correct line number');
+            assert($exception->getMessage() === 'You done goofed.', 'exception should have the correct message');
+            assert($exception->getTrace() === [], 'exception should have an empty trace');
+        });
+
+        it('should support assertions with an expression', function () {
+            $exception = null;
+            try {
+                AssertException::handle('/path/to/file', 111, 'expression', 'You done goofed.');
+            } catch (AssertException $e) {
+                $exception = $e;
+            }
+            assert($exception->getMessage() === 'expression You done goofed.', 'exception should have the correct message');
+        });
+    });
+});

--- a/specs/suiteloader.spec.php
+++ b/specs/suiteloader.spec.php
@@ -18,7 +18,7 @@ describe("SuiteLoader", function() {
     describe('->getTests()', function() {
         it("should return file paths matching *.spec.php recursively", function() {
             $tests = $this->loader->getTests($this->fixtures);
-            assert(count($tests) == 5, "suite loader should have loaded 5 specs");
+            assert(count($tests) == 6, "suite loader should have loaded 6 specs");
         });
 
         it("should return single file if it exists", function() {

--- a/src/AssertException.php
+++ b/src/AssertException.php
@@ -1,0 +1,55 @@
+<?php
+namespace Peridot;
+
+use Exception;
+use ReflectionClass;
+
+/**
+ * Represents a failed assert() call.
+ *
+ * @package Peridot
+ */
+class AssertException extends Exception
+{
+    /**
+     * Handle a failed assert() call.
+     *
+     * @param string $file
+     * @param int $line
+     * @param string $expression
+     * @param string $description
+     *
+     * @return self
+     */
+    public static function handle($file, $line, $expression, $description)
+    {
+        throw new self($file, $line, $expression, $description);
+    }
+
+    /**
+     * Construct a new assert exception.
+     *
+     * @param string $file
+     * @param int $line
+     * @param string $expression
+     * @param string $description
+     */
+    public function __construct($file, $line, $expression, $description)
+    {
+        if ($expression) {
+            $message = sprintf('%s %s', $expression, $description);
+        } else {
+            $message = $description;
+        }
+
+        parent::__construct($message);
+
+        $this->file = $file;
+        $this->line = $line;
+
+        $reflector = new ReflectionClass('Exception');
+        $traceProperty = $reflector->getProperty('trace');
+        $traceProperty->setAccessible(true);
+        $traceProperty->setValue($this, array());
+    }
+}

--- a/src/Dsl.php
+++ b/src/Dsl.php
@@ -126,6 +126,4 @@ function afterEach(callable $fn)
  * Change default assert behavior to throw exceptions
  */
 assert_options(ASSERT_WARNING, false);
-assert_options(ASSERT_CALLBACK, function ($script, $line, $message, $description) {
-    throw new Exception($description);
-});
+assert_options(ASSERT_CALLBACK, ['Peridot\AssertException', 'handle']);


### PR DESCRIPTION
This PR:
- Tidies up stack trace output by trimming stack entries that are irrelevant to the user.
- Adds the exception file and line number to the output, which was previously missing.
- Improves the exceptions thrown by failing `assert()` calls, by setting their file and line number to the location of the `assert()` call, rather than the location of the `ASSERT_CALLBACK` handler `throw` statement.

Closes #170.