### PR TITLE
When tests are focused via DSL, exit with a non-zero code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next release
 
 - **[NEW]** Introduced focused specs for powerful test isolation ([#199],
-  [#197], [#194], [#188], [#185], [#181])
+  [#204], [#197], [#194], [#188], [#185], [#181])
 - **[IMPROVED]** Stack trace output now excludes irrelevant information ([#203],
   [#170])
 - **[FIXED]** Fixed error handler signature ([#198] - thanks [@YuraLukashik])
@@ -21,6 +21,7 @@
 [#199]: https://github.com/peridot-php/peridot/pull/199
 [#201]: https://github.com/peridot-php/peridot/pull/201
 [#203]: https://github.com/peridot-php/peridot/pull/203
+[#204]: https://github.com/peridot-php/peridot/pull/204
 
 ## 1.18.1 (2016-04-23)
 

--- a/specs/command.spec.php
+++ b/specs/command.spec.php
@@ -115,5 +115,19 @@ describe('Command', function() {
                 assert($exit == 1, "exit code should be 1");
             });
         });
+
+        context('when there are DSL focused tests', function() {
+            it('should return an exit code', function() {
+                $suite = new Suite('DSL focused suite', function() {});
+                $test = new Test('focused', function() {}, true);
+                $suite->addTest($test);
+                $runner = new Runner($suite, $this->configuration, $this->emitter);
+                $command = new Command($runner, $this->configuration, $this->factory, $this->emitter);
+                $command->setApplication($this->application);
+                $exit = $command->run(new ArrayInput([], $this->definition), $this->output);
+
+                assert($exit == 2, 'exit code should be 2');
+            });
+        });
     });
 });

--- a/specs/spec-reporter.spec.php
+++ b/specs/spec-reporter.spec.php
@@ -2,6 +2,7 @@
 use Evenement\EventEmitter;
 use Peridot\Configuration;
 use Peridot\Core\Test;
+use Peridot\Core\TestResult;
 use Peridot\Reporter\SpecReporter;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -59,7 +60,7 @@ describe('SpecReporter', function() {
             $this->emitter->emit('test.passed', [new Test('passing test', function() {})]);
             $this->emitter->emit('test.failed', [new Test('failing test', function() {}), $this->exception]);
             $this->emitter->emit('test.pending', [new Test('pending test', function(){})]);
-            $this->footer = $this->reporter->footer();
+            $this->reporter->footer();
             $this->contents = $this->output->fetch();
         });
 
@@ -84,6 +85,19 @@ describe('SpecReporter', function() {
             $expectedExceptionMessage = "     ooops" . PHP_EOL . "     nextline";
             assert(strstr($this->contents, $expectedExceptionMessage) !== false, "should include exception message");
             assert(preg_match($this->expectedTrace, $this->contents), 'should include exception stack');
+        });
+    });
+
+    describe('->warnings()', function() {
+        it('should output DSL focused test warnings', function() {
+            $this->configuration->disableColors();
+            $result = new TestResult($this->emitter);
+            $result->setIsFocusedByDsl(true);
+            $this->emitter->emit('runner.end', [1.0, $result]);
+            $this->reporter->warnings($result);
+            $this->contents = $this->output->fetch();
+            $expected = 'WARNING: Tests have been focused programmatically.';
+            assert(strstr($this->contents, $expected) !== false, 'should contain DSL focused warning');
         });
     });
 

--- a/specs/test-result.spec.php
+++ b/specs/test-result.spec.php
@@ -158,4 +158,12 @@ describe("TestResult", function() {
             assert($result->getTestCount() === 1, 'should have returned test count');
         });
     });
+
+    describe('focused by DSL accessors', function () {
+        it('should allow access to the DSL focus state', function () {
+            $result = new TestResult($this->eventEmitter);
+            $result->setIsFocusedByDsl(true);
+            assert($result->isFocusedByDsl(), 'should be focused by DSL');
+        });
+    });
 });

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -145,7 +145,6 @@ class Command extends ConsoleCommand
 
         $this->eventEmitter->emit('peridot.load', [$this, $this->configuration]);
 
-
         return $this->getResult();
     }
 
@@ -177,6 +176,10 @@ class Command extends ConsoleCommand
 
         if ($result->getFailureCount() > 0) {
             return 1;
+        }
+
+        if ($result->isFocusedByDsl()) {
+            return 2;
         }
 
         return 0;

--- a/src/Core/TestResult.php
+++ b/src/Core/TestResult.php
@@ -35,6 +35,13 @@ class TestResult
     protected $pendingCount = 0;
 
     /**
+     * True if focused specs were configured via DSL functions
+     *
+     * @var bool
+     */
+    protected $isFocusedByDsl = false;
+
+    /**
      * @param EventEmitterInterface $eventEmitter
      */
     public function __construct(EventEmitterInterface $eventEmitter)
@@ -176,6 +183,27 @@ class TestResult
     public function setPendingCount($pendingCount)
     {
         $this->pendingCount = $pendingCount;
+        return $this;
+    }
+
+    /**
+     * Returns true if focused specs were configured via DSL functions
+     *
+     * @return bool
+     */
+    public function isFocusedByDsl()
+    {
+        return $this->isFocusedByDsl;
+    }
+
+    /**
+     * Mark this result as having focused specs configured via DSL functions
+     *
+     * @param bool $isFocusedByDsl
+     */
+    public function setIsFocusedByDsl($isFocusedByDsl)
+    {
+        $this->isFocusedByDsl = $isFocusedByDsl;
         return $this;
     }
 }

--- a/src/Reporter/AbstractBaseReporter.php
+++ b/src/Reporter/AbstractBaseReporter.php
@@ -6,6 +6,7 @@ use Peridot\Configuration;
 use Peridot\Core\HasEventEmitterTrait;
 use Peridot\Core\Test;
 use Peridot\Core\TestInterface;
+use Peridot\Core\TestResult;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -58,6 +59,7 @@ abstract class AbstractBaseReporter implements ReporterInterface
         'white' => ['left' => "\033[37m", 'right' => "\033[39m"],
         'success' => ['left' => "\033[32m", 'right' => "\033[39m"],
         'error' => ['left' => "\033[31m", 'right' => "\033[39m"],
+        'warning' => ['left' => "\033[33m", 'right' => "\033[39m"],
         'muted' => ['left' => "\033[90m", 'right' => "\033[0m"],
         'pending' => ['left' => "\033[36m", 'right' => "\033[39m"],
     );
@@ -184,6 +186,18 @@ abstract class AbstractBaseReporter implements ReporterInterface
             list($test, $error) = $this->errors[$i];
             $this->outputError($i + 1, $test, $error);
             $this->output->writeln('');
+        }
+    }
+
+    /**
+     * Output result warnings
+     *
+     * @param TestResult $result
+     */
+    public function warnings(TestResult $result)
+    {
+        if ($result->isFocusedByDsl()) {
+            $this->output->writeln($this->color('warning', 'WARNING: Tests have been focused programmatically.'));
         }
     }
 

--- a/src/Reporter/SpecReporter.php
+++ b/src/Reporter/SpecReporter.php
@@ -1,8 +1,9 @@
 <?php
 namespace Peridot\Reporter;
 
-use Peridot\Core\Test;
 use Peridot\Core\Suite;
+use Peridot\Core\Test;
+use Peridot\Core\TestResult;
 use Peridot\Runner\Context;
 
 /**
@@ -102,9 +103,14 @@ class SpecReporter extends AbstractBaseReporter
         ));
     }
 
-    public function onRunnerEnd()
+    /**
+     * @param float $time
+     * @param TestResult $result
+     */
+    public function onRunnerEnd($time, TestResult $result)
     {
         $this->footer();
+        $this->warnings($result);
     }
 
     /**

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -45,12 +45,7 @@ class Runner implements RunnerInterface
      */
     public function run(TestResult $result)
     {
-        $focusPattern = $this->configuration->getFocusPattern();
-        $skipPattern = $this->configuration->getSkipPattern();
-
-        if ($focusPattern !== null || $skipPattern !== null) {
-            $this->suite->applyFocusPatterns($focusPattern, $skipPattern);
-        }
+        $this->applyFocus($result);
 
         $this->eventEmitter->on('test.failed', function () {
             if ($this->configuration->shouldStopOnFailure()) {
@@ -62,6 +57,17 @@ class Runner implements RunnerInterface
         $this->suite->setEventEmitter($this->eventEmitter);
         $start = microtime(true);
         $this->suite->run($result);
-        $this->eventEmitter->emit('runner.end', [microtime(true) - $start]);
+        $this->eventEmitter->emit('runner.end', [microtime(true) - $start, $result]);
+    }
+
+    private function applyFocus(TestResult $result)
+    {
+        $result->setIsFocusedByDsl($this->suite->isFocused());
+        $focusPattern = $this->configuration->getFocusPattern();
+        $skipPattern = $this->configuration->getSkipPattern();
+
+        if ($focusPattern !== null || $skipPattern !== null) {
+            $this->suite->applyFocusPatterns($focusPattern, $skipPattern);
+        }
     }
 }


### PR DESCRIPTION
This PR implements a similar feature to this one from Ginkgo:

> When Ginkgo detects that a passing test suite has a programmatically focused test it causes the suite to exit with a non-zero status code. This is to help detect erroneously committed focused tests on CI systems. When passed a command-line focus/skip flag Ginkgo exits with status code 0 - if you want to focus tests on your CI system you should explicitly pass in a -focus or -skip flag.