### PR TITLE
Add `test` alias for `it`

### DIFF
--- a/src/Dsl.php
+++ b/src/Dsl.php
@@ -35,6 +35,17 @@ function it($description, callable $fn = null)
 }
 
 /**
+ * Identical to it. Useful for test readability
+ *
+ * @param $description
+ * @param $fn
+ */
+function test($description, callable $fn = null)
+{
+    it($description, $fn);
+}
+
+/**
  * Create a pending suite
  *
  * @param $description
@@ -68,6 +79,17 @@ function xit($description, callable $fn = null)
 }
 
 /**
+ * Create a pending spec
+ *
+ * @param $description
+ * @param callable $fn
+ */
+function xtest($description, callable $fn = null)
+{
+    xit($description, $fn);
+}
+
+/**
  * Create a focused suite
  *
  * @param $description
@@ -98,6 +120,17 @@ function fcontext($description, callable $fn)
 function fit($description, callable $fn = null)
 {
     Context::getInstance()->addTest($description, $fn, null, true);
+}
+
+/**
+ * Create a focused spec
+ *
+ * @param $description
+ * @param callable $fn
+ */
+function ftest($description, callable $fn = null)
+{
+    fit($description, $fn);
 }
 
 /**


### PR DESCRIPTION
This adds the `test` alias for `it` and the other variants. This is similar to facebook's Jest. I think there are some cases where `test` can be more suiting fo the test description.

Specifically, I've created a [package](https://github.com/krakphp/peridocs) which generates markdown documentation from your specs, and I've found that using `it` can make the wording weird, but `test` is more natural.

Btw, thank you so much for making this package, it's such a great tool!

Signed-off-by: RJ Garcia <rj@bighead.net>